### PR TITLE
First pass (incomplete) of "rich" JSONB indexing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ EQL provides specialized functions to interact with encrypted data:
 - **`cs_unique_v1(val JSONB)`**: Retrieves the unique index for enforcing uniqueness.
 - **`cs_ore_v1(val JSONB)`**: Retrieves the Order-Revealing Encryption index for range queries.
 - **`cs_ste_vec_v1(val JSONB)`**: Retrieves the Structured Encryption Vector for containment queries.
-- **`cs_rich_jsonb_v1(val JSONB)`**: Retrieves the encryptyed materialised JSONB index for rich JSONB queries.
+- **`cs_rich_jsonb_v1(val JSONB)`**: Retrieves the encrypted materialised JSONB index for rich JSONB queries.
 
 
 ### Index functions


### PR DESCRIPTION
I'm winging it a bit here.

1. I landed on `rich_jsonb` as the name of the new index type (had to pick something!)
2. I circumvented the bike-shedding naming EQL function equivalents for nameless Postgres operators by making the operator an argument to a generic `cs_binop_v1` function:

`cs_binop_v1(left_arg, '->', right_arg)`

I'm fairly certain this can be made to work in PGPLSQL