### PR TITLE
Update json payload query support

### DIFF
--- a/languages/go/goeql/goeql.go
+++ b/languages/go/goeql/goeql.go
@@ -191,7 +191,7 @@ func ToEncryptedColumn(value any, table string, column string, queryType any) (E
 	if err != nil {
 		return EncryptedColumn{}, fmt.Errorf("error: %v", err)
 	}
-	data := EncryptedColumn{K: "pt", P: str, I: TableColumn{T: table, C: column}, V: 1, Q: nil}
+	data := EncryptedColumn{K: "pt", P: str, I: TableColumn{T: table, C: column}, V: 1}
 	if queryType != nil {
 		data.Q = queryType
 	}

--- a/languages/go/goeql/goeql.go
+++ b/languages/go/goeql/goeql.go
@@ -150,21 +150,28 @@ func (eb *EncryptedBool) Deserialize(data []byte) (EncryptedBool, error) {
 	return false, fmt.Errorf("invalid format: missing 'p' field")
 }
 
+// serializes a plaintext value used in a match query
 func MatchQuery(value any, table string, column string) ([]byte, error) {
-	return SerializeQuery(value, table, column, "match")
-}
-func OreQuery(value any, table string, column string) ([]byte, error) {
-	return SerializeQuery(value, table, column, "ore")
-}
-func UniqueQuery(value any, table string, column string) ([]byte, error) {
-	return SerializeQuery(value, table, column, "unique")
-}
-func JsonbQuery(value any, table string, column string) ([]byte, error) {
-	return SerializeQuery(value, table, column, "ste_vec")
+	return serializeQuery(value, table, column, "match")
 }
 
-// SerializeQuery produces a jsonb payload used by EQL query functions to perform search operations like equality checks, range queries, and unique constraints.
-func SerializeQuery(value any, table string, column string, queryType any) ([]byte, error) {
+// serializes a plaintext value used in an ore query
+func OreQuery(value any, table string, column string) ([]byte, error) {
+	return serializeQuery(value, table, column, "ore")
+}
+
+// serializes a plaintext value used in a unique query
+func UniqueQuery(value any, table string, column string) ([]byte, error) {
+	return serializeQuery(value, table, column, "unique")
+}
+
+// serializes a plaintext value used in a jsonb query
+func JsonbQuery(value any, table string, column string) ([]byte, error) {
+	return serializeQuery(value, table, column, "ste_vec")
+}
+
+// serializeQuery produces a jsonb payload used by EQL query functions to perform search operations like equality checks, range queries, and unique constraints.
+func serializeQuery(value any, table string, column string, queryType any) ([]byte, error) {
 	query, err := ToEncryptedColumn(value, table, column, queryType)
 	if err != nil {
 		return nil, fmt.Errorf("error converting to EncryptedColumn: %v", err)

--- a/languages/go/goeql/goeql.go
+++ b/languages/go/goeql/goeql.go
@@ -150,16 +150,16 @@ func (eb *EncryptedBool) Deserialize(data []byte) (EncryptedBool, error) {
 	return false, fmt.Errorf("invalid format: missing 'p' field")
 }
 
-func SerializeMatchQuery(value any, table string, column string) ([]byte, error) {
+func MatchQuery(value any, table string, column string) ([]byte, error) {
 	return SerializeQuery(value, table, column, "match")
 }
-func SerializeOreQuery(value any, table string, column string) ([]byte, error) {
+func OreQuery(value any, table string, column string) ([]byte, error) {
 	return SerializeQuery(value, table, column, "ore")
 }
-func SerializeUniqueQuery(value any, table string, column string) ([]byte, error) {
+func UniqueQuery(value any, table string, column string) ([]byte, error) {
 	return SerializeQuery(value, table, column, "unique")
 }
-func SerializeJsonbQuery(value any, table string, column string) ([]byte, error) {
+func JsonbQuery(value any, table string, column string) ([]byte, error) {
 	return SerializeQuery(value, table, column, "ste_vec")
 }
 

--- a/languages/go/goeql/goeql.go
+++ b/languages/go/goeql/goeql.go
@@ -187,25 +187,15 @@ func serializeQuery(value any, table string, column string, queryType any) ([]by
 
 // ToEncryptedColumn converts a plaintext value to a string, and returns the EncryptedColumn struct for inserting into a database.
 func ToEncryptedColumn(value any, table string, column string, queryType any) (EncryptedColumn, error) {
-	if queryType == nil {
-		str, err := convertToString(value)
-		if err != nil {
-			return EncryptedColumn{}, fmt.Errorf("error: %v", err)
-		}
-
-		data := EncryptedColumn{K: "pt", P: str, I: TableColumn{T: table, C: column}, V: 1, Q: nil}
-
-		return data, nil
-	} else {
-		str, err := convertToString(value)
-		if err != nil {
-			return EncryptedColumn{}, fmt.Errorf("error: %v", err)
-		}
-
-		data := EncryptedColumn{K: "pt", P: str, I: TableColumn{T: table, C: column}, V: 1, Q: queryType}
-
-		return data, nil
+	str, err := convertToString(value)
+	if err != nil {
+		return EncryptedColumn{}, fmt.Errorf("error: %v", err)
 	}
+	data := EncryptedColumn{K: "pt", P: str, I: TableColumn{T: table, C: column}, V: 1, Q: nil}
+	if queryType != nil {
+		data.Q = queryType
+	}
+	return data, nil
 }
 
 func convertToString(value any) (string, error) {

--- a/languages/go/goeql/goeql.go
+++ b/languages/go/goeql/goeql.go
@@ -32,6 +32,41 @@ type EncryptedColumn struct {
 }
 
 // EncryptedText is a string value to be encrypted
+// def for_match(value)
+//     for_query(value, "match")
+//   end
+
+//   def for_ore(value)
+//     for_query(value, "ore")
+//   end
+
+//   def for_unique(value)
+//     for_query(value, "unique")
+//   end
+
+//   def for_ste_vec(value)
+//     for_query(value, "ste_vec")
+//   end
+
+//   def for_query(value, for_query)
+//     eql_payload(value, for_query).to_json()
+//   end
+
+//	def eql_payload(value, for_query)
+//	  {
+//	    k: "pt",
+//	    p: serialize_plaintext_value(value),
+//	    i: {
+//	      t: table,
+//	      c: column
+//	    },
+//	    v: 1,
+//	    q: for_query,
+//	  }
+//	end
+//
+// Creating custom types for encrypted fields to enable creating methods for
+// serialization/deserialization of these types.
 type EncryptedText string
 
 // EncryptedJsonb is a jsonb value to be encrypted

--- a/languages/go/goeql/goeql.go
+++ b/languages/go/goeql/goeql.go
@@ -150,22 +150,22 @@ func (eb *EncryptedBool) Deserialize(data []byte) (EncryptedBool, error) {
 	return false, fmt.Errorf("invalid format: missing 'p' field")
 }
 
-// serializes a plaintext value used in a match query
+// MatchQuery serializes a plaintext value used in a match query
 func MatchQuery(value any, table string, column string) ([]byte, error) {
 	return serializeQuery(value, table, column, "match")
 }
 
-// serializes a plaintext value used in an ore query
+// OreQuery serializes a plaintext value used in an ore query
 func OreQuery(value any, table string, column string) ([]byte, error) {
 	return serializeQuery(value, table, column, "ore")
 }
 
-// serializes a plaintext value used in a unique query
+// UniqueQuery serializes a plaintext value used in a unique query
 func UniqueQuery(value any, table string, column string) ([]byte, error) {
 	return serializeQuery(value, table, column, "unique")
 }
 
-// serializes a plaintext value used in a jsonb query
+// JsonbQuery serializes a plaintext value used in a jsonb query
 func JsonbQuery(value any, table string, column string) ([]byte, error) {
 	return serializeQuery(value, table, column, "ste_vec")
 }

--- a/languages/go/goeql/goeql.go
+++ b/languages/go/goeql/goeql.go
@@ -29,7 +29,7 @@ type EncryptedColumn struct {
 	P string      `json:"p"`
 	I TableColumn `json:"i"`
 	V int         `json:"v"`
-	Q any         `json:"q"`
+	Q string      `json:"q"`
 }
 
 // EncryptedText is a string value to be encrypted
@@ -46,7 +46,7 @@ type EncryptedBool bool
 
 // Serialize turns a EncryptedText value into a jsonb payload for CipherStash Proxy
 func (et EncryptedText) Serialize(table string, column string) ([]byte, error) {
-	val, err := ToEncryptedColumn(string(et), table, column, nil)
+	val, err := ToEncryptedColumn(string(et), table, column)
 	if err != nil {
 		return nil, fmt.Errorf("error serializing: %v", err)
 	}
@@ -69,7 +69,7 @@ func (et *EncryptedText) Deserialize(data []byte) (EncryptedText, error) {
 
 // Serialize turns a EncryptedJsonb value into a jsonb payload for CipherStash Proxy
 func (ej EncryptedJsonb) Serialize(table string, column string) ([]byte, error) {
-	val, err := ToEncryptedColumn(map[string]any(ej), table, column, nil)
+	val, err := ToEncryptedColumn(map[string]any(ej), table, column)
 	if err != nil {
 		return nil, fmt.Errorf("error serializing: %v", err)
 	}
@@ -97,7 +97,7 @@ func (ej *EncryptedJsonb) Deserialize(data []byte) (EncryptedJsonb, error) {
 
 // Serialize turns a EncryptedInt value into a jsonb payload for CipherStash Proxy
 func (et EncryptedInt) Serialize(table string, column string) ([]byte, error) {
-	val, err := ToEncryptedColumn(int(et), table, column, nil)
+	val, err := ToEncryptedColumn(int(et), table, column)
 	if err != nil {
 		return nil, fmt.Errorf("error serializing: %v", err)
 	}
@@ -124,7 +124,7 @@ func (et *EncryptedInt) Deserialize(data []byte) (EncryptedInt, error) {
 
 // Serialize turns a EncryptedBool value into a jsonb payload for CipherStash Proxy
 func (eb EncryptedBool) Serialize(table string, column string) ([]byte, error) {
-	val, err := ToEncryptedColumn(bool(eb), table, column, nil)
+	val, err := ToEncryptedColumn(bool(eb), table, column)
 	if err != nil {
 		return nil, fmt.Errorf("error serializing: %v", err)
 	}
@@ -171,7 +171,7 @@ func JsonbQuery(value any, table string, column string) ([]byte, error) {
 }
 
 // serializeQuery produces a jsonb payload used by EQL query functions to perform search operations like equality checks, range queries, and unique constraints.
-func serializeQuery(value any, table string, column string, queryType any) ([]byte, error) {
+func serializeQuery(value any, table string, column string, queryType string) ([]byte, error) {
 	query, err := ToEncryptedColumn(value, table, column, queryType)
 	if err != nil {
 		return nil, fmt.Errorf("error converting to EncryptedColumn: %v", err)
@@ -186,14 +186,14 @@ func serializeQuery(value any, table string, column string, queryType any) ([]by
 }
 
 // ToEncryptedColumn converts a plaintext value to a string, and returns the EncryptedColumn struct for inserting into a database.
-func ToEncryptedColumn(value any, table string, column string, queryType any) (EncryptedColumn, error) {
+func ToEncryptedColumn(value any, table string, column string, queryType ...string) (EncryptedColumn, error) {
 	str, err := convertToString(value)
 	if err != nil {
 		return EncryptedColumn{}, fmt.Errorf("error: %v", err)
 	}
 	data := EncryptedColumn{K: "pt", P: str, I: TableColumn{T: table, C: column}, V: 1}
 	if queryType != nil {
-		data.Q = queryType
+		data.Q = queryType[0]
 	}
 	return data, nil
 }

--- a/languages/go/goeql/goeql_test.go
+++ b/languages/go/goeql/goeql_test.go
@@ -210,34 +210,105 @@ func TestEncryptedBool_Deserialize(t *testing.T) {
 	}
 }
 
-// Test SerializeQuery Function
-func TestSerializeQuery(t *testing.T) {
-	tests := []struct {
-		value     interface{}
-		table     string
-		column    string
-		expectedP string
-	}{
-		{value: "test_string", table: "table1", column: "column1", expectedP: "test_string"},
-		{value: 123, table: "table2", column: "column2", expectedP: "123"},
-		{value: true, table: "table3", column: "column3", expectedP: "true"},
-		{value: map[string]interface{}{"key": "value"}, table: "table4", column: "column4", expectedP: `{"key":"value"}`},
+func TestMatchQuerySerialization(t *testing.T) {
+	value := "test_string"
+	table := "table1"
+	column := "column1"
+	expectedP := "test_string"
+	expectedQ := "match"
+
+	serializedData, err := MatchQuery(value, table, column)
+	if err != nil {
+		t.Fatalf("SerializeQuery returned error: %v", err)
 	}
 
-	for _, tt := range tests {
-		serializedData, err := SerializeQuery(tt.value, tt.table, tt.column, nil)
-		if err != nil {
-			t.Fatalf("SerializeQuery returned error: %v", err)
-		}
+	var ec EncryptedColumn
+	if err := json.Unmarshal(serializedData, &ec); err != nil {
+		t.Fatalf("Error unmarshaling serialized data: %v", err)
+	}
 
-		var ec EncryptedColumn
-		if err := json.Unmarshal(serializedData, &ec); err != nil {
-			t.Fatalf("Error unmarshaling serialized data: %v", err)
-		}
+	if ec.P != expectedP {
+		t.Errorf("Expected P to be '%s', got '%s'", expectedP, ec.P)
+	}
 
-		if ec.P != tt.expectedP {
-			t.Errorf("Expected P to be '%s', got '%s'", tt.expectedP, ec.P)
-		}
+	if ec.Q != expectedQ {
+		t.Errorf("Expected Q to be '%s', got '%s'", expectedQ, ec.Q)
+	}
+}
+func TestOreQuerySerialization(t *testing.T) {
+	value := 123
+	table := "table1"
+	column := "column1"
+	expectedP := "123"
+	expectedQ := "ore"
+
+	serializedData, err := OreQuery(value, table, column)
+	if err != nil {
+		t.Fatalf("SerializeQuery returned error: %v", err)
+	}
+
+	var ec EncryptedColumn
+	if err := json.Unmarshal(serializedData, &ec); err != nil {
+		t.Fatalf("Error unmarshaling serialized data: %v", err)
+	}
+
+	if ec.P != expectedP {
+		t.Errorf("Expected P to be '%s', got '%s'", expectedP, ec.P)
+	}
+
+	if ec.Q != expectedQ {
+		t.Errorf("Expected Q to be '%s', got '%s'", expectedQ, ec.Q)
+	}
+}
+
+func TestUniqueQuerySerialization(t *testing.T) {
+	value := true
+	table := "table1"
+	column := "column1"
+	expectedP := "true"
+	expectedQ := "unique"
+
+	serializedData, err := UniqueQuery(value, table, column)
+	if err != nil {
+		t.Fatalf("SerializeQuery returned error: %v", err)
+	}
+
+	var ec EncryptedColumn
+	if err := json.Unmarshal(serializedData, &ec); err != nil {
+		t.Fatalf("Error unmarshaling serialized data: %v", err)
+	}
+
+	if ec.P != expectedP {
+		t.Errorf("Expected P to be '%s', got '%s'", expectedP, ec.P)
+	}
+
+	if ec.Q != expectedQ {
+		t.Errorf("Expected Q to be '%s', got '%s'", expectedQ, ec.Q)
+	}
+}
+
+func TestJsonbQuerySerialization(t *testing.T) {
+	value := map[string]interface{}{"key": "value"}
+	table := "table1"
+	column := "column1"
+	expectedP := `{"key":"value"}`
+	expectedQ := "ste_vec"
+
+	serializedData, err := JsonbQuery(value, table, column)
+	if err != nil {
+		t.Fatalf("SerializeQuery returned error: %v", err)
+	}
+
+	var ec EncryptedColumn
+	if err := json.Unmarshal(serializedData, &ec); err != nil {
+		t.Fatalf("Error unmarshaling serialized data: %v", err)
+	}
+
+	if ec.P != expectedP {
+		t.Errorf("Expected P to be '%s', got '%s'", expectedP, ec.P)
+	}
+	if ec.Q != expectedQ {
+		t.Errorf("Expected Q to be '%s', got '%s'", expectedQ, ec.Q)
 	}
 }
 

--- a/languages/go/goeql/goeql_test.go
+++ b/languages/go/goeql/goeql_test.go
@@ -225,7 +225,7 @@ func TestSerializeQuery(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		serializedData, err := SerializeQuery(tt.value, tt.table, tt.column)
+		serializedData, err := SerializeQuery(tt.value, tt.table, tt.column, nil)
 		if err != nil {
 			t.Fatalf("SerializeQuery returned error: %v", err)
 		}
@@ -257,7 +257,7 @@ func TestToEncryptedColumn(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ec, err := ToEncryptedColumn(tt.value, tt.table, tt.column)
+		ec, err := ToEncryptedColumn(tt.value, tt.table, tt.column, nil)
 		if err != nil {
 			t.Fatalf("ToEncryptedColumn returned error: %v", err)
 		}

--- a/languages/go/goeql/goeql_test.go
+++ b/languages/go/goeql/goeql_test.go
@@ -328,7 +328,7 @@ func TestToEncryptedColumn(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ec, err := ToEncryptedColumn(tt.value, tt.table, tt.column, nil)
+		ec, err := ToEncryptedColumn(tt.value, tt.table, tt.column)
 		if err != nil {
 			t.Fatalf("ToEncryptedColumn returned error: %v", err)
 		}

--- a/languages/go/xorm/e2e_test.go
+++ b/languages/go/xorm/e2e_test.go
@@ -104,7 +104,7 @@ func TestMatchQueryLongString(t *testing.T) {
 
 	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
 
-	query, err := goeql.SerializeQuery("this", "examples", "encrypted_text_field")
+	query, err := goeql.SerializeMatchQuery("this", "examples", "encrypted_text_field")
 	if err != nil {
 		log.Fatalf("Error marshaling encrypted_text_field query: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestMatchQueryEmail(t *testing.T) {
 
 	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
 
-	query, err := goeql.SerializeQuery("test", "examples", "encrypted_text_field")
+	query, err := goeql.SerializeMatchQuery("test", "examples", "encrypted_text_field")
 	if err != nil {
 		log.Fatalf("Error marshaling encrypted_text_field query: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestJsonbQuerySimple(t *testing.T) {
 		},
 	}
 
-	query, errTwo := goeql.SerializeQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
+	query, errTwo := goeql.SerializeJsonbQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
 	if errTwo != nil {
 		log.Fatalf("Error marshaling encrypted_jsonb_field: %v", errTwo)
 	}
@@ -284,7 +284,7 @@ func TestJsonbQueryNested(t *testing.T) {
 		},
 	}
 
-	query, errTwo := goeql.SerializeQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
+	query, errTwo := goeql.SerializeJsonbQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
 	if errTwo != nil {
 		log.Fatalf("Error marshaling encrypted_jsonb_field: %v", errTwo)
 	}
@@ -331,7 +331,7 @@ func TestOreStringRangeQuery(t *testing.T) {
 	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
 
 	// Query
-	query, errQuery := goeql.SerializeQuery("tree", "examples", "encrypted_text_field")
+	query, errQuery := goeql.SerializeOreQuery("tree", "examples", "encrypted_text_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -378,7 +378,7 @@ func TestOreIntRangeQuery(t *testing.T) {
 	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
 
 	// Query
-	query, errQuery := goeql.SerializeQuery(32, "examples", "encrypted_int_field")
+	query, errQuery := goeql.SerializeOreQuery(32, "examples", "encrypted_int_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -434,7 +434,7 @@ func TestOreBoolRangeQuery(t *testing.T) {
 	assert.Equal(t, int64(3), inserted, "Expected to insert 3 rows")
 
 	// Query
-	query, errQuery := goeql.SerializeQuery(false, "examples", "encrypted_bool_field")
+	query, errQuery := goeql.SerializeOreQuery(false, "examples", "encrypted_bool_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -490,7 +490,7 @@ func TestUniqueStringQuery(t *testing.T) {
 	assert.Equal(t, int64(3), inserted, "Expected to insert 3 rows")
 
 	// Query
-	query, errQuery := goeql.SerializeQuery("testing two", "examples", "encrypted_text_field")
+	query, errQuery := goeql.SerializeUniqueQuery("testing two", "examples", "encrypted_text_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}

--- a/languages/go/xorm/example_queries.go
+++ b/languages/go/xorm/example_queries.go
@@ -60,7 +60,7 @@ func MatchQueryLongString(engine *xorm.Engine) {
 	fmt.Printf("Example one inserted: %+v\n", newExample)
 	fmt.Println("")
 
-	query, err := goeql.SerializeQuery("this", "examples", "encrypted_text_field")
+	query, err := goeql.SerializeMatchQuery("this", "examples", "encrypted_text_field")
 	if err != nil {
 		log.Fatalf("Error marshaling encrypted_text_field: %v", err)
 	}
@@ -93,7 +93,7 @@ func MatchQueryEmail(engine *xorm.Engine) {
 	fmt.Printf("Example two inserted!: %+v\n", newExampleTwo)
 	fmt.Println("")
 
-	query, errTwo := goeql.SerializeQuery("some", "examples", "encrypted_text_field")
+	query, errTwo := goeql.SerializeMatchQuery("some", "examples", "encrypted_text_field")
 	if errTwo != nil {
 		log.Fatalf("Error marshaling encrypted_text_field: %v", errTwo)
 	}
@@ -141,7 +141,7 @@ func JsonbQuerySimple(engine *xorm.Engine) {
 		},
 	}
 
-	query, errTwo := goeql.SerializeQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
+	query, errTwo := goeql.SerializeJsonbQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
 	if errTwo != nil {
 		log.Fatalf("Error marshaling encrypted_jsonb_field: %v", errTwo)
 	}
@@ -201,7 +201,7 @@ func JsonbQueryDeepNested(engine *xorm.Engine) {
 		},
 	}
 
-	jsonbQuery, errQuery := goeql.SerializeQuery(query, "examples", "encrypted_jsonb_field")
+	jsonbQuery, errQuery := goeql.SerializeJsonbQuery(query, "examples", "encrypted_jsonb_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -238,7 +238,7 @@ func OreStringRangeQuery(engine *xorm.Engine) {
 	fmt.Println("Examples inserted!")
 
 	// Query
-	query, errQuery := goeql.SerializeQuery("tree", "examples", "encrypted_text_field")
+	query, errQuery := goeql.SerializeOreQuery("tree", "examples", "encrypted_text_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -276,7 +276,7 @@ func OreIntRangeQuery(engine *xorm.Engine) {
 	fmt.Println("Examples inserted!", example1)
 	fmt.Println("Examples inserted!", example2)
 
-	serializedOreIntQuery, errQuery := goeql.SerializeQuery(32, "examples", "encrypted_int_field")
+	serializedOreIntQuery, errQuery := goeql.SerializeOreQuery(32, "examples", "encrypted_int_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -322,7 +322,7 @@ func OreBoolQuery(engine *xorm.Engine) {
 	fmt.Println("Example3 inserted!", example3)
 
 	// Query
-	query, errQuery := goeql.SerializeQuery(false, "examples", "encrypted_bool_field")
+	query, errQuery := goeql.SerializeOreQuery(false, "examples", "encrypted_bool_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -364,7 +364,7 @@ func UniqueStringQuery(engine *xorm.Engine) {
 	fmt.Println("Example3 inserted!", example3)
 
 	var allExamples []Example
-	query, errQuery := goeql.SerializeQuery("test two", "examples", "encrypted_text_field")
+	query, errQuery := goeql.SerializeUniqueQuery("test two", "examples", "encrypted_text_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}

--- a/languages/go/xorm/example_queries.go
+++ b/languages/go/xorm/example_queries.go
@@ -60,7 +60,7 @@ func MatchQueryLongString(engine *xorm.Engine) {
 	fmt.Printf("Example one inserted: %+v\n", newExample)
 	fmt.Println("")
 
-	query, err := goeql.SerializeMatchQuery("this", "examples", "encrypted_text_field")
+	query, err := goeql.MatchQuery("this", "examples", "encrypted_text_field")
 	if err != nil {
 		log.Fatalf("Error marshaling encrypted_text_field: %v", err)
 	}
@@ -93,7 +93,7 @@ func MatchQueryEmail(engine *xorm.Engine) {
 	fmt.Printf("Example two inserted!: %+v\n", newExampleTwo)
 	fmt.Println("")
 
-	query, errTwo := goeql.SerializeMatchQuery("some", "examples", "encrypted_text_field")
+	query, errTwo := goeql.MatchQuery("some", "examples", "encrypted_text_field")
 	if errTwo != nil {
 		log.Fatalf("Error marshaling encrypted_text_field: %v", errTwo)
 	}
@@ -141,7 +141,7 @@ func JsonbQuerySimple(engine *xorm.Engine) {
 		},
 	}
 
-	query, errTwo := goeql.SerializeJsonbQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
+	query, errTwo := goeql.JsonbQuery(jsonbQuery, "examples", "encrypted_jsonb_field")
 	if errTwo != nil {
 		log.Fatalf("Error marshaling encrypted_jsonb_field: %v", errTwo)
 	}
@@ -201,7 +201,7 @@ func JsonbQueryDeepNested(engine *xorm.Engine) {
 		},
 	}
 
-	jsonbQuery, errQuery := goeql.SerializeJsonbQuery(query, "examples", "encrypted_jsonb_field")
+	jsonbQuery, errQuery := goeql.JsonbQuery(query, "examples", "encrypted_jsonb_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -238,7 +238,7 @@ func OreStringRangeQuery(engine *xorm.Engine) {
 	fmt.Println("Examples inserted!")
 
 	// Query
-	query, errQuery := goeql.SerializeOreQuery("tree", "examples", "encrypted_text_field")
+	query, errQuery := goeql.OreQuery("tree", "examples", "encrypted_text_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -276,7 +276,7 @@ func OreIntRangeQuery(engine *xorm.Engine) {
 	fmt.Println("Examples inserted!", example1)
 	fmt.Println("Examples inserted!", example2)
 
-	serializedOreIntQuery, errQuery := goeql.SerializeOreQuery(32, "examples", "encrypted_int_field")
+	serializedOreIntQuery, errQuery := goeql.OreQuery(32, "examples", "encrypted_int_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -322,7 +322,7 @@ func OreBoolQuery(engine *xorm.Engine) {
 	fmt.Println("Example3 inserted!", example3)
 
 	// Query
-	query, errQuery := goeql.SerializeOreQuery(false, "examples", "encrypted_bool_field")
+	query, errQuery := goeql.OreQuery(false, "examples", "encrypted_bool_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}
@@ -364,7 +364,7 @@ func UniqueStringQuery(engine *xorm.Engine) {
 	fmt.Println("Example3 inserted!", example3)
 
 	var allExamples []Example
-	query, errQuery := goeql.SerializeUniqueQuery("test two", "examples", "encrypted_text_field")
+	query, errQuery := goeql.UniqueQuery("test two", "examples", "encrypted_text_field")
 	if errQuery != nil {
 		log.Fatalf("err: %v", errQuery)
 	}

--- a/languages/go/xorm/main.go
+++ b/languages/go/xorm/main.go
@@ -13,11 +13,6 @@ import (
 	"xorm.io/xorm/names"
 )
 
-// To setup postgres:
-// Run: docker compose up
-// To run examples
-// Run: go run .
-
 // Create a separate custom type for each field that is being encrypted, using the relevant go type.
 // This custom type can then be used to access the conversion interface to use toDB and fromDb.
 type EncryptedTextField string

--- a/languages/go/xorm/migrations.go
+++ b/languages/go/xorm/migrations.go
@@ -30,7 +30,7 @@ func installCsCustomTypes(engine *sql.DB) {
 
 // Installing EQL
 func installDsl(engine *sql.DB) {
-	path := "./cipherstash-encrypt-dsl.sql"
+	path := "../../../release/cipherstash-encrypt-dsl.sql"
 	sql, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("Failed to read SQL file: %v", err)


### PR DESCRIPTION
Updates the payload to include a q value.

Adds query functions to use for each type to serialize the query into the required format.

Updates goeql tests.

Points eql sql install to central release folder that contains the latest sql for eql.