### PR TITLE
Update link in README to use the generated release sql file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ EQL provides a data format for transmitting and storing encrypted data & indexes
 
 The simplest and fastest way to get up and running with EQL from scratch is to execute the install SQL file directly in your database.
 
-1. Download the [install.sql](src/install.sql) file
+1. Download the [cipherstash-encrypt-dsl.sql](./release/cipherstash-encrypt-dsl.sql) file
 2. Run the following command to install the custom types and functions:
 
 ```bash
-psql -f install.sql
+psql -f cipherstash-encrypt-dsl.sql
 ```
 
 ## Usage


### PR DESCRIPTION
All eql sql files have been moved over to this repo.

Use the file generated from running `just build` as the link in the README.