### PR TITLE
Update .envrc.example now that MLP is the default

### DIFF
--- a/cipherstash-proxy/docker-compose.yaml
+++ b/cipherstash-proxy/docker-compose.yaml
@@ -5,7 +5,6 @@ services:
     ports:
       - 6432:6432
     environment:
-      - CS_STATEMENT_HANDLER=mylittleproxy
       - LOG_LEVEL=debug
     volumes:
       - ./cipherstash-proxy.toml:/etc/cipherstash-proxy/cipherstash-proxy.toml

--- a/languages/go/xorm/.envrc.example
+++ b/languages/go/xorm/.envrc.example
@@ -17,4 +17,3 @@ export CS_DATABASE__PASSWORD=postgres
 export CS_DATABASE__NAME=gotest
 export CS_DATABASE__HOST=localhost
 export CS_TEST_ON_CHECKOUT=true
-export CS_STATEMENT_HANDLER=mylittleproxy

--- a/languages/go/xorm/docker-compose.yml
+++ b/languages/go/xorm/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       CS_DATABASE__PASSWORD: postgres
       CS_DATABASE__NAME: gotest
       CS_DATABASE__HOST: postgres
-      CS_STATEMENT_HANDLER: mylittleproxy
     networks:
       - my-network
 networks:

--- a/languages/python/jupyter_notebook/docker-compose.yml
+++ b/languages/python/jupyter_notebook/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       CS_DATABASE__PASSWORD: postgres
       CS_DATABASE__NAME: cipherstash_getting_started
       CS_DATABASE__HOST: cipherstash_getting_started_pg
-      CS_STATEMENT_HANDLER: mylittleproxy
     networks:
       - cipherstash_getting_started_nw
 


### PR DESCRIPTION
No longer need:
export CS_STATEMENT_HANDLER=mylittleproxy