### PR TITLE
Adds some cd-ing for safety in the justfile bash scripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ set positional-arguments
 test:
   #!/usr/bin/env bash
   set -euxo pipefail
+  cd "{{justfile_directory()}}"
 
   just build
   just reset
@@ -24,6 +25,7 @@ test:
 build:
   #!/usr/bin/env bash
   set -euxo pipefail
+  cd "{{justfile_directory()}}"
 
   mkdir -p release
 
@@ -64,6 +66,7 @@ build:
 reset:
   #!/usr/bin/env bash
   set -euxo pipefail
+  cd "{{justfile_directory()}}"
 
   PGPASSWORD=$CS_DATABASE__PASSWORD dropdb --force --if-exists --username ${CS_DATABASE__USERNAME:-$USER} --port $CS_DATABASE__PORT $CS_DATABASE__NAME
   PGPASSWORD=$CS_DATABASE__PASSWORD createdb --username ${CS_DATABASE__USERNAME:-$USER} --port $CS_DATABASE__PORT $CS_DATABASE__NAME


### PR DESCRIPTION
… for cases where you might be using the `justfile` from outside the repo.

I happen to be calling `just -f ~/code/encrypt-query-language/justfile reset` for my benchmarking setup; I use `.envrc` for environment management, and actually `cd`-ing over there would mean I lose said environment setup.

(`justfile_directory()` has been part of Just since v0.94 or so, so it's safe to use.)