### PR TITLE
Add test coverage for go zero value reads writes

### DIFF
--- a/languages/go/xorm/e2e_test.go
+++ b/languages/go/xorm/e2e_test.go
@@ -551,7 +551,170 @@ func TestJsonbTermsOp(t *testing.T) {
 		t.Fatalf("Could not unmarshal %v", err)
 	}
 	assert.Equal(t, expected_id, jsonData)
+}
 
+func TestJsonbNullWriteRead(t *testing.T) {
+	engine := proxyEngine()
+	truncateDb(engine)
+
+	example_one := Example{
+		NonEncryptedField:   "sydney",
+		EncryptedTextField:  "test@gmail.com",
+		EncryptedIntField:   42,
+		EncryptedJsonbField: nil,
+		EncryptedBoolField:  true,
+	}
+
+	example_two := Example{
+		NonEncryptedField:   "melbourne",
+		EncryptedIntField:   42,
+		EncryptedTextField:  "someone@gmail.com",
+		EncryptedJsonbField: make(map[string]interface{}),
+		EncryptedBoolField:  false,
+	}
+
+	examples := []Example{
+		example_one,
+		example_two,
+	}
+
+	inserted, err := engine.Insert(&examples)
+
+	if err != nil {
+		t.Errorf("Error inserting examples: %v", err)
+	}
+
+	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
+
+	var returnedExamples []Example
+	err = engine.Where("encrypted_jsonb_field IS NULL").Find(&returnedExamples)
+	if err != nil {
+		t.Fatalf("Could not retrieve example: %v", err)
+	}
+
+	for i := range returnedExamples {
+		assert.Equal(t, EncryptedJsonbField(nil), returnedExamples[i].EncryptedJsonbField)
+	}
+}
+
+func TestTextNullWriteRead(t *testing.T) {
+	engine := proxyEngine()
+	truncateDb(engine)
+
+	example_one := Example{
+		NonEncryptedField:   "sydney",
+		EncryptedIntField:   42,
+		EncryptedJsonbField: generateJsonbData("first", "second", "third"),
+		EncryptedBoolField:  true,
+	}
+
+	example_two := Example{
+		NonEncryptedField:   "melbourne",
+		EncryptedTextField:  "someone@gmail.com",
+		EncryptedIntField:   42,
+		EncryptedJsonbField: make(map[string]interface{}),
+		EncryptedBoolField:  false,
+	}
+
+	examples := []Example{
+		example_one,
+		example_two,
+	}
+
+	inserted, err := engine.Insert(&examples)
+
+	if err != nil {
+		t.Errorf("Error inserting examples: %v", err)
+	}
+
+	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
+
+	results, err := engine.Query("select * from examples")
+	if err != nil {
+		t.Fatalf("Could not retrieve examples: %v", err)
+	}
+
+	assert.Equal(t, 2, len(results))
+}
+
+func TestIntNullWriteRead(t *testing.T) {
+	engine := proxyEngine()
+	truncateDb(engine)
+
+	example_one := Example{
+		NonEncryptedField:   "sydney",
+		EncryptedTextField:  "test@gmail.com",
+		EncryptedJsonbField: generateJsonbData("first", "second", "third"),
+		EncryptedBoolField:  true,
+	}
+
+	example_two := Example{
+		NonEncryptedField:   "melbourne",
+		EncryptedTextField:  "someone@gmail.com",
+		EncryptedIntField:   42,
+		EncryptedJsonbField: make(map[string]interface{}),
+		EncryptedBoolField:  false,
+	}
+
+	examples := []Example{
+		example_one,
+		example_two,
+	}
+
+	inserted, err := engine.Insert(&examples)
+
+	if err != nil {
+		t.Errorf("Error inserting examples: %v", err)
+	}
+
+	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
+
+	results, err := engine.Query("select * from examples")
+	if err != nil {
+		t.Fatalf("Could not retrieve examples: %v", err)
+	}
+
+	assert.Equal(t, 2, len(results))
+}
+
+func TestBooleanNullWriteRead(t *testing.T) {
+	engine := proxyEngine()
+	truncateDb(engine)
+
+	// Remove boolean field
+	example_one := Example{
+		NonEncryptedField:   "sydney",
+		EncryptedTextField:  "test@gmail.com",
+		EncryptedJsonbField: generateJsonbData("first", "second", "third"),
+	}
+
+	example_two := Example{
+		NonEncryptedField:   "melbourne",
+		EncryptedTextField:  "someone@gmail.com",
+		EncryptedIntField:   42,
+		EncryptedJsonbField: make(map[string]interface{}),
+		EncryptedBoolField:  false,
+	}
+
+	examples := []Example{
+		example_one,
+		example_two,
+	}
+
+	inserted, err := engine.Insert(&examples)
+
+	if err != nil {
+		t.Errorf("Error inserting examples: %v", err)
+	}
+
+	assert.Equal(t, int64(2), inserted, "Expected to insert 2 rows")
+
+	results, err := engine.Query("select * from examples")
+	if err != nil {
+		t.Fatalf("Could not retrieve examples: %v", err)
+	}
+
+	assert.Equal(t, 2, len(results))
 }
 
 func TestOreStringRangeQuery(t *testing.T) {

--- a/languages/go/xorm/go.mod
+++ b/languages/go/xorm/go.mod
@@ -5,7 +5,7 @@ go 1.21.3
 require github.com/stretchr/testify v1.9.0
 
 require (
-	github.com/cipherstash/goeql v0.1.3
+	github.com/cipherstash/goeql v0.1.4
 	github.com/cockroachdb/apd v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect

--- a/languages/go/xorm/go.sum
+++ b/languages/go/xorm/go.sum
@@ -1,7 +1,7 @@
 gitea.com/xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a h1:lSA0F4e9A2NcQSqGqTOXqu2aRi/XEQxDCBwM8yJtE6s=
 gitea.com/xorm/sqlfiddle v0.0.0-20180821085327-62ce714f951a/go.mod h1:EXuID2Zs0pAQhH8yz+DNjUbjppKQzKFAn28TMYPB6IU=
-github.com/cipherstash/goeql v0.1.3 h1:tZrTOnPEL1KA63mw47o+FL4nQ4gOXj+PjfdFfnJKQKY=
-github.com/cipherstash/goeql v0.1.3/go.mod h1:ZCxu+TEwv3Zb82EJI/Sm8UrNKLEKg/D19Tkf08D6tCU=
+github.com/cipherstash/goeql v0.1.4 h1:Q/Vx716egrny3Hrmn1u7F9ooIJdd2VHe3qtMpJvMoUk=
+github.com/cipherstash/goeql v0.1.4/go.mod h1:ZCxu+TEwv3Zb82EJI/Sm8UrNKLEKg/D19Tkf08D6tCU=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
When inserting a jsonb value as nil, or an empty map, or not including the field on insert, the value coming through to todb is an empty map[]. This is because go sets these values to the go zero value https://go.dev/ref/spec#The_zero_value.

This PR will add a change to check for this in the EncryptedJsonb type in goeql so that we don't serialize the value into the  jsonb shape. The proxy will encrypt the value as "null", and will encrypt this. But, when trying to read, this error will return 
`handle] rewrite_results Error: Unknown variant code `11``. 

I have been testing by pointing to this branch locally https://github.com/cipherstash/goeql/pull/3

~~I will do a release of goeql and then open this PR.~~
Bumped goeql and ran tests:

<img width="602" alt="Screenshot 2024-10-30 at 5 01 47 PM" src="https://github.com/user-attachments/assets/6a878579-74b7-4799-b122-8a2e1ad2c847">

