### PR TITLE
Update 001-ore-cllw.sql with ORE comparison fix when bytea comparison is 'equal'

### DIFF
--- a/sql/001-ore-cllw.sql
+++ b/sql/001-ore-cllw.sql
@@ -150,9 +150,9 @@ BEGIN
 
     -- If the bytea comparison is 'equal', compare lengths
     IF len_a < len_b THEN
-        RETURN 1;
-    ELSIF len_a > len_b THEN
         RETURN -1;
+    ELSIF len_a > len_b THEN
+        RETURN 1;
     ELSE
         RETURN 0;
     END IF;


### PR DESCRIPTION
This change updates the ORE CLLW SQL file (001-ore-cllw.sql) with @coderdan's latest fix for when bytea comparison is 'equal'.