### PR TITLE
Add back `GROUP BY` support

### DIFF
--- a/sql/010-core.sql
+++ b/sql/010-core.sql
@@ -351,3 +351,17 @@ CREATE FUNCTION cs_ore_64_8_v1(val jsonb)
 BEGIN ATOMIC
 	RETURN cs_ore_64_8_v1_v0_0(val);
 END;
+
+DROP FUNCTION IF EXISTS _cs_first_grouped_value(jsonb, jsonb);
+
+CREATE FUNCTION _cs_first_grouped_value(jsonb, jsonb)
+RETURNS jsonb AS $$
+  SELECT COALESCE($1, $2);
+$$ LANGUAGE sql IMMUTABLE;
+
+DROP AGGREGATE IF EXISTS cs_grouped_value_v1(jsonb);
+
+CREATE AGGREGATE cs_grouped_value_v1(jsonb) (
+  SFUNC = _cs_first_grouped_value,
+  STYPE = jsonb
+);


### PR DESCRIPTION
`GROUP BY` support was accidentally removed in https://github.com/cipherstash/encrypt-query-language/pull/59.

This change adds back EQL functions for `GROUP BY` support.

Also see: https://github.com/cipherstash/encrypt-query-language/pull/55.