### PR TITLE
Add docs on native PG JSON(B) functions/ops compared to EQL

### DIFF
--- a/JSON.md
+++ b/JSON.md
@@ -14,9 +14,10 @@ or a Structured Encryption Map, `ste_map`.
 ```
 
 
-## Simplified JSON Path
+## eJSONPath
 
-CipherStash EQL supports a simplified JSONPath syntax as follows:
+CipherStash EQL supports a simplified JSONPath syntax, called `eJSONPath`.
+It is a subset of the [SQL/JSONPath](https://www.postgresql.org/docs/16/datatype-json.html#DATATYPE-JSONPATH) scheme provided by Postgres and supports the following expressions:
 
 | Expression | Description |
 |------------|-------------|

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -27,8 +27,7 @@ SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) FROM examples;
 ```
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": 100
 }
@@ -56,8 +55,7 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
 ```
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": 100
 }
@@ -116,8 +114,7 @@ SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
 With the params...
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": [1, 2, 3]
 }
@@ -169,8 +166,7 @@ WHERE (cs_ste_vec_terms_v1(examples.encrypted_jsonb, $1))[1] > cs_ste_vec_term_v
 ```
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": [4, 5, 6]
 }
@@ -227,8 +223,7 @@ SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) FROM examples;
 ```
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": {
     "field_b": 100
@@ -258,8 +253,7 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
 ```
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": {
     "field_b": 100
@@ -328,8 +322,7 @@ SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
 With the params...
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": [1, 2, 3]
 }
@@ -381,8 +374,7 @@ WHERE EXISTS (
 ```
 
 ```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
 {
   "field_a": [1, 2, 3]
 }

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -87,6 +87,119 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
 }
 ```
 
+## `json ->> int` → `text` and `json -> int` → `jsonb`/`json`
+
+### Native Postgres JSON(B)
+
+```sql
+-- `->` (returns JSON(B))
+SELECT plaintext_jsonb->0 FROM examples;
+
+-- `->>` (returns text)
+SELECT plaintext_jsonb->>0 FROM examples;
+```
+
+### EQL
+
+EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`->>`) for lookups.
+
+#### Decryption example
+
+EQL currently doesn't support returning a specific array element for decryption, but `cs_ste_vec_value_v1` can be used to return an array to the client to process.
+
+The query...
+
+```sql
+SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
+```
+
+With the params...
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": [1, 2, 3]
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a`:
+{
+  "k": "pt",
+  "p": "$.field_a",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+```
+
+Would return the EQL plaintext payload with an array (`[1, 2, 3]` for example):
+
+```javascript
+// Example result for a single row
+{
+  "k": "pt",
+  "p": "[1, 2, 3]",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": null
+}
+```
+
+#### Comparison example
+
+`cs_ste_vec_terms_v1` can be used with the native Postgres array access operator to get a term for comparison by array index.
+
+The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).
+
+> [!IMPORTANT]
+> Array access with `cs_ste_vec_terms_v1` only works when the given eJSONPath only matches a single array.
+> Accessing array elements from `cs_ste_vec_terms_v1` when the eJSONPath matches multiple arrays (for example, when there are nested arrays or multiple arrays at the same depth) can return unexpected results.
+
+The following query compares the first item in the array at the eJSONPath in $1 to the value in $2.
+
+```sql
+SELECT * FROM examples
+WHERE (cs_ste_vec_terms_v1(examples.encrypted_jsonb, $1))[1] > cs_ste_vec_term_v1($2)
+```
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": [4, 5, 6]
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a[*]`:
+{
+  "k": "pt",
+  "p": "$.field_a[*]",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+
+// `$2` is the EQL plaintext payload for the ORE term to compare against (in this case, the ORE term for the integer `3`):
+{
+  "k": "pt",
+  "p": "3",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ste_vec"
+}
+```
+
 ## `json #>> text[]` → `text` and `json #> text[]` → `jsonb`/`json`
 
 ### Native Postgres JSON(B)
@@ -290,119 +403,6 @@ WHERE EXISTS (
 {
   "k": "pt",
   "p": "2",
-  "i": {
-    "t": "examples",
-    "c": "encrypted_jsonb"
-  },
-  "v": 1,
-  "q": "ste_vec"
-}
-```
-
-## `json ->> int` → `text` and `json -> int` → `jsonb`/`json`
-
-### Native Postgres JSON(B)
-
-```sql
--- `->` (returns JSON(B))
-SELECT plaintext_jsonb->0 FROM examples;
-
--- `->>` (returns text)
-SELECT plaintext_jsonb->>0 FROM examples;
-```
-
-### EQL
-
-EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`->>`) for lookups.
-
-#### Decryption example
-
-EQL currently doesn't support returning a specific array element for decryption, but `cs_ste_vec_value_v1` can be used to return an array to the client to process.
-
-The query...
-
-```sql
-SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
-```
-
-With the params...
-
-```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
-{
-  "field_a": [1, 2, 3]
-}
-
-// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a`:
-{
-  "k": "pt",
-  "p": "$.field_a",
-  "i": {
-    "t": "examples",
-    "c": "encrypted_jsonb"
-  },
-  "v": 1,
-  "q": "ejson_path"
-}
-```
-
-Would return the EQL plaintext payload with an array (`[1, 2, 3]` for example):
-
-```javascript
-// Example result for a single row
-{
-  "k": "pt",
-  "p": "[1, 2, 3]",
-  "i": {
-    "t": "examples",
-    "c": "encrypted_jsonb"
-  },
-  "v": 1,
-  "q": null
-}
-```
-
-#### Comparison example
-
-`cs_ste_vec_terms_v1` can be used with the native Postgres array access operator to get a term for comparison by array index.
-
-The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).
-
-> [!IMPORTANT]
-> Array access with `cs_ste_vec_terms_v1` only works when the given eJSONPath only matches a single array.
-> Accessing array elements from `cs_ste_vec_terms_v1` when the eJSONPath matches multiple arrays (for example, when there are nested arrays or multiple arrays at the same depth) can return unexpected results.
-
-The following query compares the first item in the array at the eJSONPath in $1 to the value in $2.
-
-```sql
-SELECT * FROM examples
-WHERE (cs_ste_vec_terms_v1(examples.encrypted_jsonb, $1))[1] > cs_ste_vec_term_v1($2)
-```
-
-```javascript
-// Assume that examples.encrypted_jsonb has JSON objects with
-// the shape:
-{
-  "field_a": [4, 5, 6]
-}
-
-// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a[*]`:
-{
-  "k": "pt",
-  "p": "$.field_a[*]",
-  "i": {
-    "t": "examples",
-    "c": "encrypted_jsonb"
-  },
-  "v": 1,
-  "q": "ejson_path"
-}
-
-// `$2` is the EQL plaintext payload for the ORE term to compare against (in this case, the ORE term for the integer `3`):
-{
-  "k": "pt",
-  "p": "3",
   "i": {
     "t": "examples",
     "c": "encrypted_jsonb"

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -158,7 +158,7 @@ The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_a
 > Array access with `cs_ste_vec_terms_v1` only works when the given eJSONPath only matches a single array.
 > Accessing array elements from `cs_ste_vec_terms_v1` when the eJSONPath matches multiple arrays (for example, when there are nested arrays or multiple arrays at the same depth) can return unexpected results.
 
-The following query compares the first item in the array at the eJSONPath in $1 to the value in $2.
+The following query compares the first item in the array at the eJSONPath in `$1` to the value in `$2`.
 
 ```sql
 SELECT * FROM examples

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -1,6 +1,6 @@
 # Native Postgres JSON(B) Compared to EQL
 
-EQL supports a subset of functionality supported by the native Postgres JSON(B) functions and operators. The following examples compare natiive Postres JSON(B) functions and operators to the related functionality in EQL.
+EQL supports a subset of functionality supported by the native Postgres JSON(B) functions and operators. The following examples compare native Postres JSON(B) functions and operators to the related functionality in EQL.
 
 ## `json ->> text` → `text` and `json -> text` → `jsonb`/`json`
 
@@ -74,7 +74,7 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
   "q": "ejson_path"
 }
 
-// `$2` is the EQL plaintext payload for the ORE term to compare against:
+// `$2` is the EQL plaintext payload for the ORE term to compare against (in this case, the ORE term for the integer `123`):
 {
   "k": "pt",
   "p": "123",
@@ -86,10 +86,6 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
   "q": "ste_vec"
 }
 ```
-
-#### Containment example
-
-TODO: do we want containment examples for these, too?
 
 ## `json #>> text[]` → `text` and `json #> text[]` → `jsonb`/`json`
 
@@ -169,7 +165,7 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
   "q": "ejson_path"
 }
 
-// `$2` is the EQL plaintext payload for the ORE term to compare against:
+// `$2` is the EQL plaintext payload for the ORE term to compare against (in this case, the ORE term for the integer `123`):
 {
   "k": "pt",
   "p": "123",
@@ -181,10 +177,6 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
   "q": "ste_vec"
 }
 ```
-
-#### Containment example
-
-TODO: do we want containment examples for these, too?
 
 ## `json_array_elements`, `jsonb_array_elements`, `json_array_elements_text`, and `jsonb_array_elements_text`
 
@@ -294,10 +286,123 @@ WHERE EXISTS (
   "q": "ejson_path"
 }
 
-// `$2` is the EQL plaintext payload for the ORE term to compare against:
+// `$2` is the EQL plaintext payload for the ORE term to compare against  (in this case, the ORE term for the integer `2`):
 {
   "k": "pt",
   "p": "2",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ste_vec"
+}
+```
+
+## `json ->> int` → `text` and `json -> int` → `jsonb`/`json`
+
+### Native Postgres JSON(B)
+
+```sql
+-- `->` (returns JSON(B))
+SELECT plaintext_jsonb->0 FROM examples;
+
+-- `->>` (returns text)
+SELECT plaintext_jsonb->>0 FROM examples;
+```
+
+### EQL
+
+EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`->>`) for lookups.
+
+#### Decryption example
+
+EQL currently doesn't support returning a specific array element for decryption, but `cs_ste_vec_value_v1` can be used to return an array to the client to process.
+
+The query...
+
+```sql
+SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
+```
+
+With the params...
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": [1, 2, 3]
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a`:
+{
+  "k": "pt",
+  "p": "$.field_a",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+```
+
+Would return the EQL plaintext payload with an array (`[1, 2, 3]` for example):
+
+```javascript
+// Example result for a single row
+{
+  "k": "pt",
+  "p": "[1, 2, 3]",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": null
+}
+```
+
+#### Comparison example
+
+`cs_ste_vec_terms_v1` can be used with the native Postgres array access operator to get a term for comparison by array index.
+
+The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).
+
+> [!IMPORTANT]
+> Array access with `cs_ste_vec_terms_v1` only works when the given eJSONPath only matches a single array.
+> Accessing array elements from `cs_ste_vec_terms_v1` when the eJSONPath matches multiple arrays (for example, when there are nested arrays or multiple arrays at the same depth) can return unexpected results.
+
+The following query compares the first item in the array at the eJSONPath in $1 to the value in $2.
+
+```sql
+SELECT * FROM examples
+WHERE (cs_ste_vec_terms_v1(examples.encrypted_jsonb, $1))[1] > cs_ste_vec_term_v1($2)
+```
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": [4, 5, 6]
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a[*]`:
+{
+  "k": "pt",
+  "p": "$.field_a[*]",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+
+// `$2` is the EQL plaintext payload for the ORE term to compare against (in this case, the ORE term for the integer `3`):
+{
+  "k": "pt",
+  "p": "3",
   "i": {
     "t": "examples",
     "c": "encrypted_jsonb"

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -20,7 +20,7 @@ EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`-
 
 #### Decryption example
 
-`cs_ste_vec_value_v1` returns the Plaintext EQL payload to the client.
+`cs_ste_vec_value_v1` returns the plaintext EQL payload to the client.
 
 ```sql
 SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) FROM examples;
@@ -216,7 +216,7 @@ Note that these are similar to the examples for `->`/`->>`. The difference in th
 
 #### Decryption example
 
-`cs_ste_vec_value_v1` returns the Plaintext EQL payload to the client.
+`cs_ste_vec_value_v1` returns the plaintext EQL payload to the client.
 
 ```sql
 SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) FROM examples;

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -212,7 +212,8 @@ SELECT plaintext_jsonb#>>'{field_a,field_b}' FROM examples;
 
 EQL JSONB functions accept an eJSONPath as an argument (instead of using `#>`/`#>>`) for lookups.
 
-Note that these are similar to the examples for `->`/`->>`. The difference in these examples is that the path does a lookup multiple levels deep.
+Note that these are similar to the examples for `->`/`->>`. 
+The difference in these examples is that the path does a lookup multiple levels deep.
 
 #### Decryption example
 
@@ -409,7 +410,8 @@ Would return the EQL plaintext payload with an array (`[1, 2, 3]` for example):
 
 #### Comparison example
 
-`cs_ste_vec_terms_v1` (note that terms is plural) can be used to return an array of ORE terms for comparison. The array can be `unnest`ed to work with a `SETOF` ORE terms for comparison.
+`cs_ste_vec_terms_v1` (note that terms is plural) can be used to return an array of ORE terms for comparison. 
+The array can be `unnest`ed to work with a `SETOF` ORE terms for comparison.
 
 The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).
 

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -1,6 +1,6 @@
 # Native PostgreSQL JSON(B) Compared to EQL
 
-EQL supports a subset of functionality supported by the native PostgreSQL JSON(B) functions and operators. 
+EQL supports a subset of functionality supported by the native PostgreSQL JSON(B) functions and operators.
 The following examples compare native PostgreSQL JSON(B) functions and operators to the related functionality in EQL.
 
 ## `json ->> text` → `text` and `json -> text` → `jsonb`/`json`
@@ -17,7 +17,7 @@ SELECT plaintext_jsonb->>'field_a' FROM examples;
 
 ### EQL
 
-EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`->>`) for lookups.
+EQL JSONB functions accept an [eJSONPath](./JSON.md) as an argument (instead of using `->`/`->>`) for lookups.
 
 #### Decryption example
 
@@ -100,7 +100,7 @@ SELECT plaintext_jsonb->>0 FROM examples;
 
 ### EQL
 
-EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`->>`) for lookups.
+EQL JSONB functions accept an [eJSONPath](./JSON.md) as an argument (instead of using `->`/`->>`) for lookups.
 
 #### Decryption example
 
@@ -211,9 +211,9 @@ SELECT plaintext_jsonb#>>'{field_a,field_b}' FROM examples;
 
 ### EQL
 
-EQL JSONB functions accept an eJSONPath as an argument (instead of using `#>`/`#>>`) for lookups.
+EQL JSONB functions accept an [eJSONPath](./JSON.md) as an argument (instead of using `#>`/`#>>`) for lookups.
 
-Note that these are similar to the examples for `->`/`->>`. 
+Note that these are similar to the examples for `->`/`->>`.
 The difference in these examples is that the path does a lookup multiple levels deep.
 
 #### Decryption example
@@ -411,7 +411,7 @@ Would return the EQL plaintext payload with an array (`[1, 2, 3]` for example):
 
 #### Comparison example
 
-`cs_ste_vec_terms_v1` (note that terms is plural) can be used to return an array of ORE terms for comparison. 
+`cs_ste_vec_terms_v1` (note that terms is plural) can be used to return an array of ORE terms for comparison.
 The array can be `unnest`ed to work with a `SETOF` ORE terms for comparison.
 
 The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -285,6 +285,57 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
 }
 ```
 
+## `@>` and `<@`
+
+### Native Postgres JSON(B)
+
+```sql
+-- Checks if the left arg contains the right arg (returns `true` in this example).
+SELECT '{"a":1, "b":2}'::jsonb @> '{"b":2}'::jsonb;
+
+-- Checks if the right arg contains the left arg (returns `true` in this example).
+SELECT '{"b":2}'::jsonb <@ '{"a":1, "b":2}'::jsonb;
+```
+
+### EQL
+
+EQL uses the same operators for containment (`@>` and `<@`) queries, but the args need to be wrapped in `cs_ste_vec_v1`.
+
+Example query:
+
+```sql
+-- Checks if the left arg (the `examples.encrypted_jsonb` column) contains the right arg ($1).
+-- Would return `true` for the example data and param below.
+SELECT * WHERE cs_ste_vec_v1(encrypted_jsonb) @> cs_ste_vec_v1($1) FROM examples;
+
+-- Checks if the the right arg ($1) contains left arg (the `examples.encrypted_jsonb` column).
+-- Would return `false` for the example data and param below.
+SELECT * WHERE cs_ste_vec_v1(encrypted_jsonb) <@ cs_ste_vec_v1($1) FROM examples;
+```
+
+Example params:
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with the shape:
+{
+  "field_a": {
+    "field_b": [1, 2, 3]
+  }
+}
+
+// `$1` is the EQL plaintext payload for the JSON object `{"field_b": [1, 2, 3]}`:
+{
+  "k": "pt",
+  "p": "{\"field_b\": [1, 2, 3]}",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ste_vec"
+}
+```
+
 ## `json_array_elements`, `jsonb_array_elements`, `json_array_elements_text`, and `jsonb_array_elements_text`
 
 ### Native Postgres JSON(B)

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -105,13 +105,13 @@ EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`-
 
 EQL currently doesn't support returning a specific array element for decryption, but `cs_ste_vec_value_v1` can be used to return an array to the client to process.
 
-The query...
+The query:
 
 ```sql
 SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
 ```
 
-With the params...
+With the params:
 
 ```javascript
 // Assume that examples.encrypted_jsonb has JSON objects with the shape:
@@ -364,13 +364,13 @@ SELECT * from jsonb_array_elements_text('["a", "b"]');
 
 EQL currently doesn't support returning a `SETOF` values for decryption (for returning a row per item in an array), but `cs_ste_vec_value_v1` can be used to return an array to the client to process.
 
-The query...
+The query:
 
 ```sql
 SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
 ```
 
-With the params...
+With the params:
 
 ```javascript
 // Assume that examples.encrypted_jsonb has JSON objects with the shape:

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -1,10 +1,10 @@
-# Native Postgres JSON(B) Compared to EQL
+# Native PostgreSQL JSON(B) Compared to EQL
 
 EQL supports a subset of functionality supported by the native Postgres JSON(B) functions and operators. The following examples compare native Postres JSON(B) functions and operators to the related functionality in EQL.
 
 ## `json ->> text` → `text` and `json -> text` → `jsonb`/`json`
 
-### Native Postgres JSON(B)
+### Native PostgreSQL JSON(B)
 
 ```sql
 -- `->` (returns JSON(B))
@@ -87,7 +87,7 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
 
 ## `json ->> int` → `text` and `json -> int` → `jsonb`/`json`
 
-### Native Postgres JSON(B)
+### Native PostgreSQL JSON(B)
 
 ```sql
 -- `->` (returns JSON(B))
@@ -150,7 +150,7 @@ Would return the EQL plaintext payload with an array (`[1, 2, 3]` for example):
 
 #### Comparison example
 
-`cs_ste_vec_terms_v1` can be used with the native Postgres array access operator to get a term for comparison by array index.
+`cs_ste_vec_terms_v1` can be used with the native PostgreSQL array access operator to get a term for comparison by array index.
 
 The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).
 
@@ -198,7 +198,7 @@ WHERE (cs_ste_vec_terms_v1(examples.encrypted_jsonb, $1))[1] > cs_ste_vec_term_v
 
 ## `json #>> text[]` → `text` and `json #> text[]` → `jsonb`/`json`
 
-### Native Postgres JSON(B)
+### Native PostgreSQL JSON(B)
 
 ```sql
 -- `#>` (returns JSON(B))
@@ -287,7 +287,7 @@ WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
 
 ## `@>` and `<@`
 
-### Native Postgres JSON(B)
+### Native PostgreSQL JSON(B)
 
 ```sql
 -- Checks if the left arg contains the right arg (returns `true` in this example).
@@ -338,7 +338,7 @@ Example params:
 
 ## `json_array_elements`, `jsonb_array_elements`, `json_array_elements_text`, and `jsonb_array_elements_text`
 
-### Native Postgres JSON(B)
+### Native PostgreSQL JSON(B)
 
 ```sql
 -- Each returns the results...
@@ -457,7 +457,7 @@ WHERE EXISTS (
 
 ## `json_array_length` and `jsonb_array_length`
 
-### Native Postgres JSON(B)
+### Native PostgreSQL JSON(B)
 
 ```sql
 -- Both of these examples return the int `3`.
@@ -468,7 +468,7 @@ SELECT jsonb_array_length('[1, 2, 3]');
 
 ### EQL
 
-The Postgres `array_length` function can be used with `cs_ste_vec_terms_v1` to find the length of an array.
+The PostgreSQL `array_length` function can be used with `cs_ste_vec_terms_v1` to find the length of an array.
 
 The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).
 

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -1,6 +1,7 @@
 # Native PostgreSQL JSON(B) Compared to EQL
 
-EQL supports a subset of functionality supported by the native Postgres JSON(B) functions and operators. The following examples compare native Postres JSON(B) functions and operators to the related functionality in EQL.
+EQL supports a subset of functionality supported by the native PostgreSQL JSON(B) functions and operators. 
+The following examples compare native PostgreSQL JSON(B) functions and operators to the related functionality in EQL.
 
 ## `json ->> text` → `text` and `json -> text` → `jsonb`/`json`
 

--- a/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
+++ b/NATIVE_POSTGRES_JSON_COMPARED_TO_EQL.md
@@ -1,0 +1,308 @@
+# Native Postgres JSON(B) Compared to EQL
+
+EQL supports a subset of functionality supported by the native Postgres JSON(B) functions and operators. The following examples compare natiive Postres JSON(B) functions and operators to the related functionality in EQL.
+
+## `json ->> text` → `text` and `json -> text` → `jsonb`/`json`
+
+### Native Postgres JSON(B)
+
+```sql
+-- `->` (returns JSON(B))
+SELECT plaintext_jsonb->'field_a' FROM examples;
+
+-- `->>` (returns text)
+SELECT plaintext_jsonb->>'field_a' FROM examples;
+```
+
+### EQL
+
+EQL JSONB functions accept an eJSONPath as an argument (instead of using `->`/`->>`) for lookups.
+
+#### Decryption example
+
+`cs_ste_vec_value_v1` returns the Plaintext EQL payload to the client.
+
+```sql
+SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) FROM examples;
+```
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": 100
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a`:
+{
+  "k": "pt",
+  "p": "$.field_a",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+```
+
+#### Comparison example
+
+`cs_ste_vec_term_v1` returns an ORE term for comparison.
+
+```sql
+SELECT * FROM examples
+WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
+```
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": 100
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a`:
+{
+  "k": "pt",
+  "p": "$.field_a",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+
+// `$2` is the EQL plaintext payload for the ORE term to compare against:
+{
+  "k": "pt",
+  "p": "123",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ste_vec"
+}
+```
+
+#### Containment example
+
+TODO: do we want containment examples for these, too?
+
+## `json #>> text[]` → `text` and `json #> text[]` → `jsonb`/`json`
+
+### Native Postgres JSON(B)
+
+```sql
+-- `#>` (returns JSON(B))
+SELECT plaintext_jsonb#>'{field_a,field_b}' FROM examples;
+
+-- `#>>` (returns text)
+SELECT plaintext_jsonb#>>'{field_a,field_b}' FROM examples;
+```
+
+### EQL
+
+EQL JSONB functions accept an eJSONPath as an argument (instead of using `#>`/`#>>`) for lookups.
+
+Note that these are similar to the examples for `->`/`->>`. The difference in these examples is that the path does a lookup multiple levels deep.
+
+#### Decryption example
+
+`cs_ste_vec_value_v1` returns the Plaintext EQL payload to the client.
+
+```sql
+SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) FROM examples;
+```
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": {
+    "field_b": 100
+  }
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a.field_b`:
+{
+  "k": "pt",
+  "p": "$.field_a.field_b",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+```
+
+#### Comparison example
+
+`cs_ste_vec_term_v1` returns an ORE term for comparison.
+
+```sql
+SELECT * FROM examples
+WHERE cs_ste_vec_term_v1(examples.encrypted_jsonb, $1) > cs_ste_vec_term_v1($2)
+```
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": {
+    "field_b": 100
+  }
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a.field_b`:
+{
+  "k": "pt",
+  "p": "$.field_a.field_b",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+
+// `$2` is the EQL plaintext payload for the ORE term to compare against:
+{
+  "k": "pt",
+  "p": "123",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ste_vec"
+}
+```
+
+#### Containment example
+
+TODO: do we want containment examples for these, too?
+
+## `json_array_elements`, `jsonb_array_elements`, `json_array_elements_text`, and `jsonb_array_elements_text`
+
+### Native Postgres JSON(B)
+
+```sql
+-- Each returns the results...
+--
+-- Value
+-- _____
+-- a
+-- b
+--
+-- The only difference is that the input is either json or jsonb (depending
+-- on the prefix of the function name) and the output is either json,
+-- jsonb, or text (depending on both the prefix and the suffix).
+
+SELECT * from json_array_elements('["a", "b"]');
+SELECT * from jsonb_array_elements('["a", "b"]');
+SELECT * from json_array_elements_text('["a", "b"]');
+SELECT * from jsonb_array_elements_text('["a", "b"]');
+```
+
+### EQL
+
+#### Decryption example
+
+EQL currently doesn't support returning a `SETOF` values for decryption (for returning a row per item in an array), but `cs_ste_vec_value_v1` can be used to return an array to the client to process.
+
+The query...
+
+```sql
+SELECT cs_ste_vec_value_v1(encrypted_jsonb, $1) AS val FROM examples;
+```
+
+With the params...
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": [1, 2, 3]
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a`:
+{
+  "k": "pt",
+  "p": "$.field_a",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+```
+
+Would return the EQL plaintext payload with an array (`[1, 2, 3]` for example):
+
+```javascript
+// Example result for a single row
+{
+  "k": "pt",
+  "p": "[1, 2, 3]",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": null
+}
+```
+
+#### Comparison example
+
+`cs_ste_vec_terms_v1` (note that terms is plural) can be used to return an array of ORE terms for comparison. The array can be `unnest`ed to work with a `SETOF` ORE terms for comparison.
+
+The eJSONPath used with `cs_ste_vec_terms_v1` needs to end with `[*]` (`$.some_array_field[*]` for example).
+
+Example query:
+
+```sql
+SELECT id FROM examples e
+WHERE EXISTS (
+  SELECT 1
+  FROM  unnest(cs_ste_vec_terms_v1(e.encrypted_jsonb, $1)) AS term
+  WHERE term > cs_ste_vec_term_v1($2)
+);
+```
+
+```javascript
+// Assume that examples.encrypted_jsonb has JSON objects with
+// the shape:
+{
+  "field_a": [1, 2, 3]
+}
+
+// `$1` is the EQL plaintext payload for the eJSONPath `$.field_a[*]`:
+{
+  "k": "pt",
+  "p": "$.field_a[*]",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ejson_path"
+}
+
+// `$2` is the EQL plaintext payload for the ORE term to compare against:
+{
+  "k": "pt",
+  "p": "2",
+  "i": {
+    "t": "examples",
+    "c": "encrypted_jsonb"
+  },
+  "v": 1,
+  "q": "ste_vec"
+}
+```


### PR DESCRIPTION
This PR adds docs that compare native Postgres JSON(B) functions and operators to JSON(B) support in EQL.

Functions and operators covered:
- `->`/`->>`
- `#>`/`#>>`
- `@>`/`<@`
- `json_array_elements`, `jsonb_array_elements`, `json_array_elements_text`, and `jsonb_array_elements_text`
- `json_array_length`