### PR TITLE
Convert the release-eql workflow to work with mise

### DIFF
--- a/.github/workflows/release-eql.yml
+++ b/.github/workflows/release-eql.yml
@@ -27,15 +27,17 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Install asdf & tools
-        uses: asdf-vm/actions/install@v3
+      - uses: jdx/mise-action@v2
+        with:
+          version: 2025.1.6 # [default: latest] mise version to install
+          install: true # [default: true] run `mise install`
+          cache: true # [default: true] cache mise using GitHub's cache
 
       - name: Build EQL release
         run: |
-          just build
+          mise run build
 
       - name: Upload EQL artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Functionally the same, but now #79 is merged, it uses `mise`. 