### PR TITLE
Correctly cast and handle nulls for order ops

### DIFF
--- a/src/encrypted/casts.sql
+++ b/src/encrypted/casts.sql
@@ -9,6 +9,10 @@
 CREATE FUNCTION eql_v2.to_encrypted(data jsonb)
 RETURNS public.eql_v2_encrypted AS $$
 BEGIN
+    IF data IS NULL THEN
+        RETURN NULL;
+    END IF;
+
     RETURN ROW(data)::public.eql_v2_encrypted;
 END;
 $$ LANGUAGE plpgsql;
@@ -28,6 +32,10 @@ CREATE CAST (jsonb AS public.eql_v2_encrypted)
 CREATE FUNCTION eql_v2.to_encrypted(data text)
 RETURNS public.eql_v2_encrypted AS $$
 BEGIN
+    IF data IS NULL THEN
+        RETURN NULL;
+    END IF;
+
     RETURN ROW(data::jsonb)::public.eql_v2_encrypted;
 END;
 $$ LANGUAGE plpgsql;
@@ -48,6 +56,10 @@ CREATE CAST (text AS public.eql_v2_encrypted)
 CREATE FUNCTION eql_v2.to_jsonb(e public.eql_v2_encrypted)
 RETURNS jsonb AS $$
 BEGIN
+    IF e IS NULL THEN
+        RETURN NULL;
+    END IF;
+
     RETURN e.data;
 END;
 $$ LANGUAGE plpgsql;

--- a/src/operators/operator_class.sql
+++ b/src/operators/operator_class.sql
@@ -22,6 +22,18 @@ AS $$
     a_ore := eql_v2.ore_block_u64_8_256(a);
     b_ore := eql_v2.ore_block_u64_8_256(b);
 
+    IF a_ore IS NULL AND b_ore IS NULL THEN
+      RETURN 0;
+    END IF;
+
+    IF a_ore IS NULL THEN
+      RETURN -1;
+    END IF;
+
+    IF b_ore IS NULL THEN
+      RETURN 1;
+    END IF;
+
     RETURN eql_v2.compare_ore_array(a_ore.terms, b_ore.terms);
   END;
 $$ LANGUAGE plpgsql;

--- a/src/ore_block_u64_8_256/functions.sql
+++ b/src/ore_block_u64_8_256/functions.sql
@@ -54,6 +54,10 @@ CREATE FUNCTION eql_v2.ore_block_u64_8_256(val jsonb)
   IMMUTABLE STRICT PARALLEL SAFE
 AS $$
 	BEGIN
+    IF val IS NULL THEN
+      RETURN NULL;
+    END IF;
+
     IF val ? 'ob' THEN
       RETURN eql_v2.jsonb_array_to_ore_block_u64_8_256(val->'ob');
     END IF;


### PR DESCRIPTION
Changes:

Cast NULL` encrypted values as `NULL` 
The previous behaviour would wrap the `NULL` value into the ROW/Composite type.
This meant records would be created as empty tuples `()` rather than NULL. 

Additional handling of NULL in the comparison function to explicitly return.
