### PR TITLE
EQL: remove zero-downtime migration workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ SELECT eql_v2.add_column('users', 'encrypted_email');
 
 **Note:** This function allows you to encrypt and decrypt data but does not enable searchable encryption. See [Searching data with EQL](#searching-data-with-eql) for enabling searchable encryption.
 
+<!--
+NOTE: NO LONGER REQUIRED
+      DOCUMENTATION CAN BE UPDATED WHEN/IF ZERO DOWNTIME SUPPORT IS ADDED TO PROXY
 ### Activating configuration
 
 After modifying configurations, activate them by running:
@@ -106,6 +109,7 @@ After modifying configurations, activate them by running:
 SELECT eql_v2.migrate_config();
 SELECT eql_v2.activate_config();
 ```
+-->
 
 **Important:** These functions must be run after any modifications to the configuration.
 

--- a/src/config/config_test.sql
+++ b/src/config/config_test.sql
@@ -25,11 +25,11 @@ DO $$
   BEGIN
 
     -- Add indexes
-    PERFORM eql_v2.add_search_config('users', 'name', 'match');
+    PERFORM eql_v2.add_search_config('users', 'name', 'match', migrating => true);
     ASSERT (SELECT _search_config_exists('users', 'name', 'match'));
 
     -- Add index with cast
-    PERFORM eql_v2.add_search_config('users', 'name', 'unique', 'int');
+    PERFORM eql_v2.add_search_config('users', 'name', 'unique', 'int', migrating => true);
     ASSERT (SELECT _search_config_exists('users', 'name', 'unique'));
 
     ASSERT (SELECT EXISTS (SELECT id FROM eql_v2_configuration c
@@ -60,7 +60,7 @@ DO $$
   BEGIN
 
     -- Add indexes
-    PERFORM eql_v2.add_search_config('users', 'name', 'match');
+    PERFORM eql_v2.add_search_config('users', 'name', 'match', migrating => true);
     ASSERT (SELECT _search_config_exists('users', 'name', 'match'));
 
     ASSERT (SELECT EXISTS (SELECT id FROM eql_v2_configuration c
@@ -68,7 +68,7 @@ DO $$
             c.data #> array['tables', 'users', 'name', 'indexes'] ? 'match'));
 
     -- Add index with cast
-    PERFORM eql_v2.add_search_config('blah', 'vtha', 'unique', 'int');
+    PERFORM eql_v2.add_search_config('blah', 'vtha', 'unique', 'int', migrating => true);
     ASSERT (SELECT _search_config_exists('blah', 'vtha', 'unique'));
 
     ASSERT (SELECT EXISTS (SELECT id FROM eql_v2_configuration c
@@ -107,11 +107,11 @@ $$ LANGUAGE plpgsql;
 
 DO $$
   BEGIN
-    PERFORM eql_v2.add_search_config('users', 'name', 'match');
+    PERFORM eql_v2.add_search_config('users', 'name', 'match', migrating => true);
     ASSERT (SELECT _search_config_exists('users', 'name', 'match'));
 
     -- Pending configuration contains the path `user/name.match.option`
-    PERFORM eql_v2.modify_search_config('users', 'name', 'match', 'int', '{"option": "value"}'::jsonb);
+    PERFORM eql_v2.modify_search_config('users', 'name', 'match', 'int', '{"option": "value"}'::jsonb, migrating => true);
     ASSERT (SELECT _search_config_exists('users', 'name', 'match'));
 
     ASSERT (SELECT EXISTS (SELECT id FROM eql_v2_configuration c
@@ -162,7 +162,7 @@ DO $$
   BEGIN
     ASSERT (SELECT _search_config_exists('users', 'blah', 'match', 'active'));
 
-    PERFORM eql_v2.add_search_config('users', 'name', 'match');
+    PERFORM eql_v2.add_search_config('users', 'name', 'match', migrating => true);
 
     -- index added to name
     ASSERT (SELECT _search_config_exists('users', 'name', 'match' ));
@@ -205,7 +205,7 @@ DO $$
     -- reset the table
     PERFORM create_table_with_encrypted();
 
-    PERFORM eql_v2.add_column('encrypted', 'e');
+    PERFORM eql_v2.add_column('encrypted', 'e', migrating => true);
 
     PERFORM assert_count(
         'Pending configuration was created',
@@ -213,7 +213,7 @@ DO $$
         1);
 
 
-    PERFORM eql_v2.remove_column('encrypted', 'e');
+    PERFORM eql_v2.remove_column('encrypted', 'e', migrating => true);
 
     PERFORM assert_no_result(
         'Pending configuration was removed',


### PR DESCRIPTION
Make zero downtime migration workflow optional  and no longer required `eql_v2.migrate_config()` and `eql_v2.activate_config()` as the default. 

Config is now immediately active unless `add_search_config` is passed a `migrating` param of `true`


```
SELECT eql_v2.add_search_config('users', 'name', 'match', migrating => true);
```

