### PR TITLE
jsonb accessors return with metadata

### DIFF
--- a/src/encrypted/functions.sql
+++ b/src/encrypted/functions.sql
@@ -85,3 +85,13 @@ AS $$
   END;
 $$ LANGUAGE plpgsql;
 
+
+CREATE FUNCTION eql_v2.meta_data(val eql_v2_encrypted)
+  RETURNS jsonb
+  IMMUTABLE STRICT PARALLEL SAFE
+AS $$
+  BEGIN
+     RETURN eql_v2.meta_data(val.data);
+  END;
+$$ LANGUAGE plpgsql;
+

--- a/src/operators/->.sql
+++ b/src/operators/->.sql
@@ -25,13 +25,17 @@ CREATE FUNCTION eql_v2."->"(e eql_v2_encrypted, selector text)
   IMMUTABLE STRICT PARALLEL SAFE
 AS $$
   DECLARE
+    meta jsonb;
     sv eql_v2_encrypted[];
-    found eql_v2_encrypted;
+    found jsonb;
 	BEGIN
 
     IF e IS NULL THEN
       RETURN NULL;
     END IF;
+
+    -- Column identifier and version
+    meta := eql_v2.meta_data(e);
 
     sv := eql_v2.ste_vec(e);
 
@@ -41,7 +45,7 @@ AS $$
       END IF;
     END LOOP;
 
-    RETURN found;
+    RETURN (meta || found)::eql_v2_encrypted;
   END;
 $$ LANGUAGE plpgsql;
 

--- a/src/operators/->_test.sql
+++ b/src/operators/->_test.sql
@@ -99,3 +99,20 @@ DO $$
   END;
 $$ LANGUAGE plpgsql;
 
+
+--
+-- Field accessor returns column metadata
+--
+DO $$
+  DECLARE
+    result jsonb;
+  BEGIN
+    PERFORM seed_encrypted_json();
+
+    SELECT e->'2517068c0d1f9d4d41d2c666211f785e'::text FROM encrypted LIMIT 1 INTO result;
+
+    ASSERT result ? 'i';
+    ASSERT result ? 'v';
+
+  END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Column meta data is required for encryption.

This pulls metadata from the column (the `i/identifier` field with table and column names) and merges with the returned stevec element. 
