### PR TITLE
Treat single element ste vec as eql_v2_encrypted

### DIFF
--- a/src/operators/compare.sql
+++ b/src/operators/compare.sql
@@ -59,7 +59,9 @@ AS $$
       RETURN 1;
     END IF;
 
-    -- Use ORE if both parameters have ore index
+    a := eql_v2.to_ste_vec_value(a);
+    b := eql_v2.to_ste_vec_value(b);
+
     IF eql_v2.has_ore_block_u64_8_256(a) AND eql_v2.has_ore_block_u64_8_256(b) THEN
       RETURN eql_v2.compare_ore_block_u64_8_256(a, b);
     END IF;
@@ -72,7 +74,6 @@ AS $$
       RETURN eql_v2.compare_ore_cllw_var_8(a, b);
     END IF;
 
-    -- Fallback to hmac if both parameters have hmac index
     IF eql_v2.has_hmac_256(a) AND eql_v2.has_hmac_256(b) THEN
       RETURN eql_v2.compare_hmac_256(a, b);
     END IF;

--- a/src/ste_vec/functions_test.sql
+++ b/src/ste_vec/functions_test.sql
@@ -28,17 +28,56 @@ $$ LANGUAGE plpgsql;
 DO $$
   DECLARE
     e eql_v2_encrypted;
-    sv eql_v2_encrypted[];
   BEGIN
     e := '{ "a": 1 }'::jsonb::eql_v2_encrypted;
     ASSERT eql_v2.is_ste_vec_array(e);
-
 
     e := '{ "a": 0 }'::jsonb::eql_v2_encrypted;
     ASSERT NOT eql_v2.is_ste_vec_array(e);
 
     e := '{ }'::jsonb::eql_v2_encrypted;
     ASSERT NOT eql_v2.is_ste_vec_array(e);
+  END;
+$$ LANGUAGE plpgsql;
+
+
+DO $$
+  DECLARE
+    e jsonb;
+  BEGIN
+    -- extract the ste_vec array item as an eeql_v2_encrypted
+    e := eql_v2.to_ste_vec_value('{ "i": "i", "v": 2, "sv": [ { "ocf": "ocf" }] }'::jsonb);
+
+    ASSERT e ? 'i';
+    ASSERT e ? 'v';
+    ASSERT e ? 'ocf';
+
+    -- Returns the original if not an stevec value
+    e := eql_v2.to_ste_vec_value('{ "i": "i", "v": 2, "b3": "b3" }'::jsonb);
+
+    ASSERT e ? 'i';
+    ASSERT e ? 'v';
+    ASSERT e ? 'b3';
+
+  END;
+$$ LANGUAGE plpgsql;
+
+
+
+DO $$
+  DECLARE
+    e eql_v2_encrypted;
+    sv eql_v2_encrypted[];
+  BEGIN
+    e := '{ "sv": [1] }'::jsonb::eql_v2_encrypted;
+    ASSERT eql_v2.is_ste_vec_value(e);
+
+    e := '{ "sv": [] }'::jsonb::eql_v2_encrypted;
+    ASSERT NOT eql_v2.is_ste_vec_value(e);
+
+    e := '{ }'::jsonb::eql_v2_encrypted;
+    ASSERT NOT eql_v2.is_ste_vec_value(e);
+
   END;
 $$ LANGUAGE plpgsql;
 


### PR DESCRIPTION
An encrypted JSONB value contains an array of nested encrypted values for each indexed field path. 

Where an SteVec has a single element, it can be treated as an `eql_v2_encrypted` when compared in the various equality operators. 

This adds a check to the core `compare` function that will "promote" the encrypted element of a single-element SteVec to an encrypted with meta data.






