### PR TITLE
fix: config functions remove process

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,37 @@ These frameworks use EQL to enable searchable encryption functionality in Postgr
 | Protect.php | [Protect.php](https://github.com/cipherstash/protectphp) |
 | CipherStash Proxy | [CipherStash Proxy](https://github.com/cipherstash/proxy) |
 
+## Versioning
+
+You can find the version of EQL installed in your database by running the following query:
+
+```sql
+SELECT eql_v2.version();
+```
+
+### Upgrading
+
+To upgrade to the latest version of EQL, you can simply run the install script again.
+
+1. Download the latest EQL install script:
+
+   ```sh
+   curl -sLo cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql
+   ```
+
+2. Run this command to install the custom types and functions:
+
+   ```sh
+   psql -f cipherstash-encrypt.sql
+   ```
+
+> [!NOTE]
+> The install script will not remove any existing configurations, so you can safely run it multiple times.
+
+#### Using dbdev?
+
+Follow the instructions in the [dbdev documentation](https://database.dev/cipherstash/eql) to upgrade the extension to your desired version.
+
 ## Developing
 
 See the [development guide](./DEVELOPMENT.md).

--- a/dbdev/eql.control
+++ b/dbdev/eql.control
@@ -1,3 +1,3 @@
-default_version = 2.1.2
+default_version = 2.1.3
 comment = 'Index and search encrypted data in PostgreSQL with SQL'
 relocatable = true

--- a/tasks/postgres.toml
+++ b/tasks/postgres.toml
@@ -21,6 +21,11 @@ mise run postgres:up --extra-args "--detach --wait"
 ["postgres:psql"]
 description = "Run psql"
 run = """
-{% set default_service = "postgres-" ~ get_env(name="POSTGRES_VERSION",default="17") %}
-psql -U {{arg(name="user",default="cipherstash")}} -d {{arg(name="db",default="cipherstash")}} -h localhost -p {{arg(name="port",default="7432")}} --service {{arg(name="service",default=default_service)}}
+psql -U {{arg(name="user",default="cipherstash")}} -d {{arg(name="db",default="cipherstash")}} -h localhost -p {{arg(name="port",default="7432")}}
+"""
+
+["eql:install"]
+description = "Install EQL to local postgres"
+run = """
+psql -U {{arg(name="user",default="cipherstash")}} -d {{arg(name="db",default="cipherstash")}} -h localhost -p {{arg(name="port",default="7432")}} -f {{arg(name="file",default="release/cipherstash-encrypt.sql")}}
 """


### PR DESCRIPTION
Fixes issues with EQL configuration remove functions and updates documentation to match current behavior.

## Issues Fixed

1. **Remove functions failing on empty configurations**: Functions would delete pending configs but still try to migrate them, causing "No pending configuration exists to encrypt" errors
2. **Database constraints rejecting empty configs**: Updated constraints to allow empty `tables` and properly handle missing `cast_as` fields  
3. **Aggressive cleanup in remove_search_config**: Now only removes the specific index instead of the entire column configuration
4. **Outdated documentation**: Added missing `migrating` parameter and clarified behavioral differences

## Breaking Changes

None - remove is now working as expected 