### PR TITLE
fix: make min & max delegate to comparison ops directly

### DIFF
--- a/src/encrypted/aggregates.sql
+++ b/src/encrypted/aggregates.sql
@@ -9,7 +9,7 @@ CREATE FUNCTION eql_v2.min(a eql_v2_encrypted, b eql_v2_encrypted)
 STRICT
 AS $$
   BEGIN
-    IF eql_v2.ore_block_u64_8_256(a) < eql_v2.ore_block_u64_8_256(b) THEN
+    IF a < b THEN
       RETURN a;
     ELSE
       RETURN b;
@@ -30,7 +30,7 @@ RETURNS eql_v2_encrypted
 STRICT
 AS $$
   BEGIN
-    IF eql_v2.ore_block_u64_8_256(a) > eql_v2.ore_block_u64_8_256(b) THEN
+    IF a > b THEN
       RETURN a;
     ELSE
       RETURN b;

--- a/src/operators/order_by.sql
+++ b/src/operators/order_by.sql
@@ -4,7 +4,6 @@
 -- REQUIRE: src/ore_block_u64_8_256/operators.sql
 -- REQUIRE: src/ore_cllw_u64_8/types.sql
 -- REQUIRE: src/ore_cllw_u64_8/functions.sql
--- REQUIRE: src/ore_cllw_u64_8/operators.sql
 
 -- order_by function for ordering when operators are not available.
 --


### PR DESCRIPTION
This means our precedence rules in eql_v2.compare will be respected (as well as making use of *any other* ORE indexes that may be present.

Paired with @tobyhede 