### PR TITLE
Add immutable to cast functions 

### DIFF
--- a/src/encrypted/casts.sql
+++ b/src/encrypted/casts.sql
@@ -7,8 +7,8 @@
 --
 
 CREATE FUNCTION eql_v2.to_encrypted(data jsonb)
-RETURNS public.eql_v2_encrypted
-IMMUTABLE STRICT PARALLEL SAFE
+    RETURNS public.eql_v2_encrypted
+    IMMUTABLE STRICT PARALLEL SAFE
 AS $$
 BEGIN
     IF data IS NULL THEN
@@ -33,7 +33,7 @@ CREATE CAST (jsonb AS public.eql_v2_encrypted)
 --
 
 CREATE FUNCTION eql_v2.to_encrypted(data text)
-RETURNS public.eql_v2_encrypted
+    RETURNS public.eql_v2_encrypted
     IMMUTABLE STRICT PARALLEL SAFE
 AS $$
 BEGIN
@@ -60,7 +60,9 @@ CREATE CAST (text AS public.eql_v2_encrypted)
 --
 
 CREATE FUNCTION eql_v2.to_jsonb(e public.eql_v2_encrypted)
-RETURNS jsonb AS $$
+    RETURNS jsonb
+    IMMUTABLE STRICT PARALLEL SAFE
+AS $$
 BEGIN
     IF e IS NULL THEN
         RETURN NULL;

--- a/src/encrypted/casts.sql
+++ b/src/encrypted/casts.sql
@@ -7,7 +7,9 @@
 --
 
 CREATE FUNCTION eql_v2.to_encrypted(data jsonb)
-RETURNS public.eql_v2_encrypted AS $$
+RETURNS public.eql_v2_encrypted
+IMMUTABLE STRICT PARALLEL SAFE
+AS $$
 BEGIN
     IF data IS NULL THEN
         RETURN NULL;
@@ -16,6 +18,7 @@ BEGIN
     RETURN ROW(data)::public.eql_v2_encrypted;
 END;
 $$ LANGUAGE plpgsql;
+
 
 --
 -- Cast jsonb to eql_v2.encrypted
@@ -30,15 +33,18 @@ CREATE CAST (jsonb AS public.eql_v2_encrypted)
 --
 
 CREATE FUNCTION eql_v2.to_encrypted(data text)
-RETURNS public.eql_v2_encrypted AS $$
+RETURNS public.eql_v2_encrypted
+    IMMUTABLE STRICT PARALLEL SAFE
+AS $$
 BEGIN
     IF data IS NULL THEN
         RETURN NULL;
     END IF;
 
-    RETURN ROW(data::jsonb)::public.eql_v2_encrypted;
+    RETURN eql_v2.to_encrypted(data::jsonb);
 END;
 $$ LANGUAGE plpgsql;
+
 
 --
 -- Cast text to eql_v2.encrypted

--- a/src/operators/operator_class_test.sql
+++ b/src/operators/operator_class_test.sql
@@ -164,6 +164,16 @@ DO $$
       RAISE EXCEPTION 'Expected Index Only Scan: %', result;
     END IF;
 
+    -- Cast to jsonb
+    EXECUTE 'EXPLAIN ANALYZE SELECT e::jsonb FROM encrypted WHERE e = ''{"hm": "abc"}''::jsonb;' into result;
+
+     -- INDEX IS NOT USED
+    IF position('Seq Scan on encrypted' in result) > 0 THEN
+      ASSERT true;
+    ELSE
+      RAISE EXCEPTION 'Unexpected Seq Scan: %', result;
+    END IF;
+
     -- Cast to jsonb to eql_v2_encrypted
     EXECUTE 'EXPLAIN ANALYZE SELECT e::jsonb FROM encrypted WHERE e = ''{"hm": "abc"}''::jsonb::eql_v2_encrypted;' into result;
 

--- a/src/operators/operator_class_test.sql
+++ b/src/operators/operator_class_test.sql
@@ -152,8 +152,48 @@ DO $$
     INSERT INTO encrypted (e) VALUES ('("{\"hm\": \"abc\"}")');
     INSERT INTO encrypted (e) VALUES ('("{\"hm\": \"def\"}")');
     INSERT INTO encrypted (e) VALUES ('("{\"hm\": \"ghi\"}")');
+    INSERT INTO encrypted (e) VALUES ('("{\"hm\": \"jkl\"}")');
+    INSERT INTO encrypted (e) VALUES ('("{\"hm\": \"mno\"}")');
 
+    -- Literal row type type thing
     EXECUTE 'EXPLAIN ANALYZE SELECT e::jsonb FROM encrypted WHERE e = ''("{\"hm\": \"abc\"}")'';' into result;
+
+    IF position('Index Only Scan using encrypted' in result) > 0 THEN
+      ASSERT true;
+    ELSE
+      RAISE EXCEPTION 'Expected Index Only Scan: %', result;
+    END IF;
+
+    -- Cast to jsonb to eql_v2_encrypted
+    EXECUTE 'EXPLAIN ANALYZE SELECT e::jsonb FROM encrypted WHERE e = ''{"hm": "abc"}''::jsonb::eql_v2_encrypted;' into result;
+
+    IF position('Index Only Scan using encrypted' in result) > 0 THEN
+      ASSERT true;
+    ELSE
+      RAISE EXCEPTION 'Expected Index Only Scan: %', result;
+    END IF;
+
+    -- Cast to text to eql_v2_encrypted
+    EXECUTE 'EXPLAIN ANALYZE SELECT e::jsonb FROM encrypted WHERE e = ''{"hm": "abc"}''::text::eql_v2_encrypted;' into result;
+
+    IF position('Index Only Scan using encrypted' in result) > 0 THEN
+      ASSERT true;
+    ELSE
+      RAISE EXCEPTION 'Expected Index Only Scan: %', result;
+    END IF;
+
+    -- Use to_encrypted with jsonb
+    EXECUTE 'EXPLAIN ANALYZE SELECT e::jsonb FROM encrypted WHERE e = eql_v2.to_encrypted(''{"hm": "abc"}''::jsonb);' into result;
+
+    IF position('Index Only Scan using encrypted' in result) > 0 THEN
+      ASSERT true;
+    ELSE
+      RAISE EXCEPTION 'Expected Index Only Scan: %', result;
+    END IF;
+
+    -- Use to_encrypted with text
+    EXECUTE 'EXPLAIN ANALYZE SELECT e::jsonb FROM encrypted WHERE e = eql_v2.to_encrypted(''{"hm": "abc"}'');' into result;
+
 
     IF position('Index Only Scan using encrypted' in result) > 0 THEN
       ASSERT true;

--- a/src/operators/order_by.sql
+++ b/src/operators/order_by.sql
@@ -1,7 +1,6 @@
 -- REQUIRE: src/encrypted/types.sql
 -- REQUIRE: src/ore_block_u64_8_256/types.sql
 -- REQUIRE: src/ore_block_u64_8_256/functions.sql
--- REQUIRE: src/ore_block_u64_8_256/operators.sql
 -- REQUIRE: src/ore_cllw_u64_8/types.sql
 -- REQUIRE: src/ore_cllw_u64_8/functions.sql
 


### PR DESCRIPTION
Given an encrypted column and an index defined as

```
CREATE INDEX encrypted_index ON encrypted (e eql_v2.encrypted_operator_class);
```

Indexes are not being used when the compared value was `cast`.

```
SELECT e::jsonb FROM encrypted WHERE e = '{"hm": "abc"}'::jsonb;
SELECT e::jsonb FROM encrypted WHERE e = '{"hm": "abc"}'::jsonb::encrypted;
```

Indexes are used when the value is the full literal tuple type
```
SELECT e::jsonb FROM encrypted WHERE e = '("{\"hm\": \"abc\"}")';
```

Adding the `IMMUTABLE` volatility category to the the type cast functions resolves the issue.

