### PR TITLE
feat(bench): Phase 3 — static data bench assertions and regression tests

### DIFF
--- a/tests/sqlx/fixtures/FIXTURE_SCHEMA.md
+++ b/tests/sqlx/fixtures/FIXTURE_SCHEMA.md
@@ -152,7 +152,7 @@ CREATE TABLE bench (
 ```
 
 **Data:**
-- 10,000 rows drawn from 99 distinct encrypted values (ore ids 1-99)
+- 10,000 rows drawn from 99 distinct encrypted values via `create_encrypted_json()` helper ids 1-99 (which map to ORE rows 10, 20, ..., 990)
 - Zipf-like skew via `setseed(0.42)` + `random()^2` — deterministic and byte-identical across runs
 - Top id gets ~5% of rows; tail ids ~0.5% each (top:bottom ratio ~10x)
 - Each column draws independently, so column values are decorrelated within a row

--- a/tests/sqlx/fixtures/bench_data.sql
+++ b/tests/sqlx/fixtures/bench_data.sql
@@ -1,8 +1,10 @@
 -- Fixture: bench_data.sql
 --
 -- Seeds 10K rows into the bench table for performance testing.
--- Each column draws independently from 99 distinct encrypted values (ore ids 1-99)
--- using a Zipf-like skew so the planner sees realistic histograms.
+-- Each column draws independently from 99 distinct create_encrypted_json() inputs
+-- (helper ids 1-99) using a Zipf-like skew so the planner sees realistic histograms.
+-- create_encrypted_json(id) maps helper ids to ORE rows at id * 10 (helper ids 1-99 →
+-- ORE rows 10, 20, ..., 990).
 --
 -- Index terms per row: hm (hmac), b3 (blake3), bf (bloom filter), ob (ORE blocks), sv (STE vec)
 -- Data generated via create_encrypted_json() from 004_install_test_helpers.sql.

--- a/tests/sqlx/src/helpers.rs
+++ b/tests/sqlx/src/helpers.rs
@@ -44,22 +44,26 @@ pub async fn get_ore_text_encrypted(pool: &PgPool, id: i32) -> Result<String> {
 ///
 /// The bench table is created by the bench_data fixture (10K rows, ids 1-10000).
 pub async fn get_bench_encrypted_int(pool: &PgPool, id: i32) -> Result<String> {
-    sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = $1")
-        .bind(id)
-        .fetch_one(pool)
-        .await
-        .with_context(|| format!("fetching bench encrypted_int for id={id}"))
+    let result: Option<String> =
+        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = $1")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .with_context(|| format!("fetching bench encrypted_int for id={id}"))?;
+    result.with_context(|| format!("bench.encrypted_int is NULL for id={id}"))
 }
 
 /// Fetch encrypted_text value from the bench table by id
 ///
 /// The bench table is created by the bench_data fixture (10K rows, ids 1-10000).
 pub async fn get_bench_encrypted_text(pool: &PgPool, id: i32) -> Result<String> {
-    sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = $1")
-        .bind(id)
-        .fetch_one(pool)
-        .await
-        .with_context(|| format!("fetching bench encrypted_text for id={id}"))
+    let result: Option<String> =
+        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = $1")
+            .bind(id)
+            .fetch_one(pool)
+            .await
+            .with_context(|| format!("fetching bench encrypted_text for id={id}"))?;
+    result.with_context(|| format!("bench.encrypted_text is NULL for id={id}"))
 }
 
 /// Assert sorted rows match expected sequential id range

--- a/tests/sqlx/src/helpers.rs
+++ b/tests/sqlx/src/helpers.rs
@@ -40,6 +40,28 @@ pub async fn get_ore_text_encrypted(pool: &PgPool, id: i32) -> Result<String> {
     result.with_context(|| format!("ore_text returned NULL for id={}", id))
 }
 
+/// Fetch encrypted_int value from the bench table by id
+///
+/// The bench table is created by the bench_data fixture (10K rows, ids 1-10000).
+pub async fn get_bench_encrypted_int(pool: &PgPool, id: i32) -> Result<String> {
+    sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .with_context(|| format!("fetching bench encrypted_int for id={id}"))
+}
+
+/// Fetch encrypted_text value from the bench table by id
+///
+/// The bench table is created by the bench_data fixture (10K rows, ids 1-10000).
+pub async fn get_bench_encrypted_text(pool: &PgPool, id: i32) -> Result<String> {
+    sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = $1")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .with_context(|| format!("fetching bench encrypted_text for id={id}"))
+}
+
 /// Assert sorted rows match expected sequential id range
 pub fn assert_sequential_ids(rows: &[sqlx::postgres::PgRow], start: i64, end: i64) {
     let ids: Vec<i64> = rows.iter().map(|r| r.try_get(0).unwrap()).collect();

--- a/tests/sqlx/src/lib.rs
+++ b/tests/sqlx/src/lib.rs
@@ -13,11 +13,11 @@ pub use assertions::QueryAssertion;
 pub use helpers::{
     analyze_table, assert_no_seq_scan, assert_sequential_ids, assert_uses_index,
     assert_uses_seq_scan, create_jsonb_gin_index, ensure_pg_stat_statements, explain_analyze_avg,
-    explain_json, explain_query, get_encrypted_term, get_ore_encrypted, get_ore_encrypted_as_jsonb,
-    get_ore_text_encrypted, get_ore_text_encrypted_as_jsonb, get_ste_vec_encrypted,
-    get_ste_vec_encrypted_pair, get_ste_vec_selector_term, get_ste_vec_sv_element,
-    get_ste_vec_term_by_id, read_pg_stat_statements, reset_pg_stat_statements, ExplainStats,
-    PgStatEntry,
+    explain_json, explain_query, get_bench_encrypted_int, get_bench_encrypted_text,
+    get_encrypted_term, get_ore_encrypted, get_ore_encrypted_as_jsonb, get_ore_text_encrypted,
+    get_ore_text_encrypted_as_jsonb, get_ste_vec_encrypted, get_ste_vec_encrypted_pair,
+    get_ste_vec_selector_term, get_ste_vec_sv_element, get_ste_vec_term_by_id,
+    read_pg_stat_statements, reset_pg_stat_statements, ExplainStats, PgStatEntry,
 };
 pub use index_types as IndexTypes;
 pub use selectors::Selectors;

--- a/tests/sqlx/tests/bench_data_tests.rs
+++ b/tests/sqlx/tests/bench_data_tests.rs
@@ -12,6 +12,14 @@ use sqlx::PgPool;
 
 const BENCH_ROW_COUNT: i64 = 10000;
 
+async fn fetch_sample_encrypted_text(pool: &PgPool) -> Result<String> {
+    Ok(
+        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
+            .fetch_one(pool)
+            .await?,
+    )
+}
+
 // ========== Data Integrity Tests ==========
 
 /// Verify fixture seeded exactly 10K rows
@@ -113,10 +121,7 @@ async fn bench_encrypted_bigint_has_ore_terms(pool: PgPool) -> Result<()> {
 /// Verify hash index is used for hmac_256 equality lookup
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn bench_hmac_equality_uses_hash_index(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
-            .fetch_one(&pool)
-            .await?;
+    let encrypted = fetch_sample_encrypted_text(&pool).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE eql_v2.hmac_256(encrypted_text) = eql_v2.hmac_256('{}'::jsonb::eql_v2_encrypted)",
@@ -137,10 +142,7 @@ async fn bench_ore_order_uses_btree_index(pool: PgPool) -> Result<()> {
 /// Verify GIN index is used for bloom_filter containment
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn bench_bloom_containment_uses_gin_index(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
-            .fetch_one(&pool)
-            .await?;
+    let encrypted = fetch_sample_encrypted_text(&pool).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE eql_v2.bloom_filter(encrypted_text) @> eql_v2.bloom_filter('{}'::jsonb::eql_v2_encrypted)",
@@ -171,10 +173,7 @@ async fn bench_ore_bigint_order_uses_btree_index(pool: PgPool) -> Result<()> {
 async fn bench_hmac_without_index_uses_seq_scan(pool: PgPool) -> Result<()> {
     analyze_table(&pool, "bench").await?;
 
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
-            .fetch_one(&pool)
-            .await?;
+    let encrypted = fetch_sample_encrypted_text(&pool).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE eql_v2.hmac_256(encrypted_text) = eql_v2.hmac_256('{}'::jsonb::eql_v2_encrypted)",

--- a/tests/sqlx/tests/bench_plan_tests.rs
+++ b/tests/sqlx/tests/bench_plan_tests.rs
@@ -1,0 +1,115 @@
+//! Tier 1 benchmark plan assertions
+//!
+//! EXPLAIN-based tests asserting each P0/P1 query pattern uses the expected
+//! index access method. Tests for known-broken patterns are marked #[ignore].
+
+use anyhow::Result;
+use eql_tests::assert_uses_index;
+use sqlx::PgPool;
+
+/// ORE range query (less-than) uses btree index
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn ore_int_range_lt_uses_btree_index(pool: PgPool) -> Result<()> {
+    let encrypted: String =
+        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 50")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_int < '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        encrypted
+    );
+    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    Ok(())
+}
+
+/// ORE range query (greater-than) uses btree index
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn ore_int_range_gt_uses_btree_index(pool: PgPool) -> Result<()> {
+    let encrypted: String =
+        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 50")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_int > '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        encrypted
+    );
+    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    Ok(())
+}
+
+/// ORE combined range (>= low AND <= high) uses btree index
+///
+/// Uses explicit >= / <= rather than BETWEEN — BETWEEN's operator resolution
+/// against eql_v2_encrypted is untested and may not resolve to the btree family.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn ore_int_range_combined_uses_btree_index(pool: PgPool) -> Result<()> {
+    let low: String =
+        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 10")
+            .fetch_one(&pool)
+            .await?;
+    let high: String =
+        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 90")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_int >= '{}'::jsonb::eql_v2_encrypted AND encrypted_int <= '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        low, high
+    );
+    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    Ok(())
+}
+
+/// eql_cast equality should use hash index — currently seq scans (CIP-2831)
+///
+/// "eql_cast" refers to the implicit JSONB-to-eql_v2_encrypted assignment cast
+/// defined in `src/encrypted/casts.sql` (`CREATE CAST (jsonb AS eql_v2_encrypted)
+/// WITH FUNCTION eql_v2.to_encrypted(jsonb)`). The SQL under test uses
+/// `'...'::jsonb::eql_v2_encrypted`, which invokes that cast. PostgreSQL does not
+/// recognise this cast path as equivalent to the indexed `hmac_256` term, so the
+/// planner falls back to a sequential scan instead of using `bench_text_hmac_idx`.
+///
+/// Remove #[ignore] when eql_cast index usage is fixed. At 1M rows this query
+/// takes 7.83s vs 0.4ms for hmac_256 — a 19,500x regression.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[ignore = "CIP-2831: eql_cast equality performs full seq scan, no index used"]
+async fn eql_cast_equality_uses_hash_index(pool: PgPool) -> Result<()> {
+    let encrypted: String =
+        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_text = '{}'::jsonb::eql_v2_encrypted",
+        encrypted
+    );
+    assert_uses_index(&pool, &sql, "bench_text_hmac_idx").await?;
+    Ok(())
+}
+
+/// ORE equality via operator class should use btree — currently seq scans (CIP-2831)
+///
+/// Like `eql_cast_equality_uses_hash_index`, the SQL uses `'...'::jsonb::eql_v2_encrypted`
+/// (the implicit JSONB assignment cast from `src/encrypted/casts.sql`). For integer
+/// columns with ORE index terms the planner should satisfy equality via the btree
+/// operator class, but the cast path prevents index recognition and causes a seq scan.
+///
+/// Remove #[ignore] when ORE equality index usage is fixed. At 1M rows this
+/// query takes 18.47s vs 0.4ms for hmac_256.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[ignore = "CIP-2831: ORE equality via operator class performs full seq scan"]
+async fn ore_equality_uses_btree_index(pool: PgPool) -> Result<()> {
+    let encrypted: String =
+        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 1")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_int = '{}'::jsonb::eql_v2_encrypted",
+        encrypted
+    );
+    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    Ok(())
+}

--- a/tests/sqlx/tests/bench_plan_tests.rs
+++ b/tests/sqlx/tests/bench_plan_tests.rs
@@ -2,40 +2,40 @@
 //!
 //! EXPLAIN-based tests asserting each P0/P1 query pattern uses the expected
 //! index access method. Tests for known-broken patterns are marked #[ignore].
+//!
+//! ANALYZE is run by the bench_setup fixture — planner statistics are populated at fixture load.
 
 use anyhow::Result;
-use eql_tests::assert_uses_index;
+use eql_tests::{assert_uses_index, get_bench_encrypted_int, get_bench_encrypted_text};
 use sqlx::PgPool;
+
+const BENCH_INT_ORE_IDX: &str = "bench_int_ore_idx";
 
 /// ORE range query (less-than) uses btree index
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn ore_int_range_lt_uses_btree_index(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 50")
-            .fetch_one(&pool)
-            .await?;
+    let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
     let sql = format!(
-        "SELECT * FROM bench WHERE encrypted_int < '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        "SELECT * FROM bench WHERE encrypted_int < '{}'::jsonb::eql_v2_encrypted \
+         ORDER BY encrypted_int LIMIT 10",
         encrypted
     );
-    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    assert_uses_index(&pool, &sql, BENCH_INT_ORE_IDX).await?;
     Ok(())
 }
 
 /// ORE range query (greater-than) uses btree index
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn ore_int_range_gt_uses_btree_index(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 50")
-            .fetch_one(&pool)
-            .await?;
+    let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
     let sql = format!(
-        "SELECT * FROM bench WHERE encrypted_int > '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        "SELECT * FROM bench WHERE encrypted_int > '{}'::jsonb::eql_v2_encrypted \
+         ORDER BY encrypted_int LIMIT 10",
         encrypted
     );
-    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    assert_uses_index(&pool, &sql, BENCH_INT_ORE_IDX).await?;
     Ok(())
 }
 
@@ -45,20 +45,17 @@ async fn ore_int_range_gt_uses_btree_index(pool: PgPool) -> Result<()> {
 /// against eql_v2_encrypted is untested and may not resolve to the btree family.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn ore_int_range_combined_uses_btree_index(pool: PgPool) -> Result<()> {
-    let low: String =
-        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 10")
-            .fetch_one(&pool)
-            .await?;
-    let high: String =
-        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 90")
-            .fetch_one(&pool)
-            .await?;
+    let low = get_bench_encrypted_int(&pool, 10).await?;
+    let high = get_bench_encrypted_int(&pool, 90).await?;
 
     let sql = format!(
-        "SELECT * FROM bench WHERE encrypted_int >= '{}'::jsonb::eql_v2_encrypted AND encrypted_int <= '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        "SELECT * FROM bench \
+         WHERE encrypted_int >= '{}'::jsonb::eql_v2_encrypted \
+           AND encrypted_int <= '{}'::jsonb::eql_v2_encrypted \
+         ORDER BY encrypted_int LIMIT 10",
         low, high
     );
-    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    assert_uses_index(&pool, &sql, BENCH_INT_ORE_IDX).await?;
     Ok(())
 }
 
@@ -73,13 +70,11 @@ async fn ore_int_range_combined_uses_btree_index(pool: PgPool) -> Result<()> {
 ///
 /// Remove #[ignore] when eql_cast index usage is fixed. At 1M rows this query
 /// takes 7.83s vs 0.4ms for hmac_256 — a 19,500x regression.
+/// Passing with the 10K-row fixture confirms index usage — timing data above was measured at 1M rows.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 #[ignore = "CIP-2831: eql_cast equality performs full seq scan, no index used"]
 async fn eql_cast_equality_uses_hash_index(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
-            .fetch_one(&pool)
-            .await?;
+    let encrypted = get_bench_encrypted_text(&pool, 1).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE encrypted_text = '{}'::jsonb::eql_v2_encrypted",
@@ -96,20 +91,19 @@ async fn eql_cast_equality_uses_hash_index(pool: PgPool) -> Result<()> {
 /// columns with ORE index terms the planner should satisfy equality via the btree
 /// operator class, but the cast path prevents index recognition and causes a seq scan.
 ///
+/// CIP-2831 covers both this and `eql_cast_equality_uses_hash_index` as a single root cause fix.
 /// Remove #[ignore] when ORE equality index usage is fixed. At 1M rows this
 /// query takes 18.47s vs 0.4ms for hmac_256.
+/// Passing with the 10K-row fixture confirms index usage — timing data above was measured at 1M rows.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 #[ignore = "CIP-2831: ORE equality via operator class performs full seq scan"]
 async fn ore_equality_uses_btree_index(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 1")
-            .fetch_one(&pool)
-            .await?;
+    let encrypted = get_bench_encrypted_int(&pool, 1).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE encrypted_int = '{}'::jsonb::eql_v2_encrypted",
         encrypted
     );
-    assert_uses_index(&pool, &sql, "bench_int_ore_idx").await?;
+    assert_uses_index(&pool, &sql, BENCH_INT_ORE_IDX).await?;
     Ok(())
 }

--- a/tests/sqlx/tests/bench_plan_tests.rs
+++ b/tests/sqlx/tests/bench_plan_tests.rs
@@ -10,6 +10,7 @@ use eql_tests::{assert_uses_index, get_bench_encrypted_int, get_bench_encrypted_
 use sqlx::PgPool;
 
 const BENCH_INT_ORE_IDX: &str = "bench_int_ore_idx";
+const BENCH_TEXT_HMAC_IDX: &str = "bench_text_hmac_idx";
 
 /// ORE range query (less-than) uses btree index
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
@@ -80,7 +81,7 @@ async fn eql_cast_equality_uses_hash_index(pool: PgPool) -> Result<()> {
         "SELECT * FROM bench WHERE encrypted_text = '{}'::jsonb::eql_v2_encrypted",
         encrypted
     );
-    assert_uses_index(&pool, &sql, "bench_text_hmac_idx").await?;
+    assert_uses_index(&pool, &sql, BENCH_TEXT_HMAC_IDX).await?;
     Ok(())
 }
 

--- a/tests/sqlx/tests/bench_regression_tests.rs
+++ b/tests/sqlx/tests/bench_regression_tests.rs
@@ -11,7 +11,9 @@
 //! for their #[ignore] plan assertions.
 
 use anyhow::Result;
-use eql_tests::{explain_analyze_avg, get_bench_encrypted_int, get_bench_encrypted_text, ExplainStats};
+use eql_tests::{
+    explain_analyze_avg, get_bench_encrypted_int, get_bench_encrypted_text, ExplainStats,
+};
 use sqlx::PgPool;
 
 /// hmac_256 equality must stay under 50ms on 10K rows (expected ~0.5ms)
@@ -55,7 +57,8 @@ async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
 /// ORE range query (< LIMIT 10) must stay under 200ms on 10K rows (expected ~2ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
-    // id=50 is the distribution midpoint → ~4,900 rows below threshold
+    // id=50 is the bench row midpoint; encrypted_int uses a +33 offset so this maps
+    // to ore id 83, but the 10K distribution still yields ~4,900 rows below the predicate
     let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
     let sql = format!(
@@ -79,9 +82,12 @@ async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
 /// observed baseline — to absorb CI variance while catching catastrophic regressions.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn ore_order_by_under_threshold(pool: PgPool) -> Result<()> {
-    let stats: ExplainStats =
-        explain_analyze_avg(&pool, "SELECT * FROM bench ORDER BY encrypted_int LIMIT 10", 5)
-            .await?;
+    let stats: ExplainStats = explain_analyze_avg(
+        &pool,
+        "SELECT * FROM bench ORDER BY encrypted_int LIMIT 10",
+        5,
+    )
+    .await?;
     assert!(
         stats.execution_time_ms < 2000.0,
         "ORE ORDER BY LIMIT 10 took {:.1}ms, threshold 2000ms (observed ~543ms baseline at 10K rows, node_type={})",

--- a/tests/sqlx/tests/bench_regression_tests.rs
+++ b/tests/sqlx/tests/bench_regression_tests.rs
@@ -1,0 +1,94 @@
+//! Tier 1 benchmark magnitude regression tests
+//!
+//! Asserts execution time stays under generous thresholds (~100x expected)
+//! to catch catastrophic regressions while tolerating CI runner variance.
+//! Uses EXPLAIN ANALYZE averaged over 5 runs for server-side timing.
+//!
+//! Patterns known to be broken (P0 seq scans) are NOT included here — encoding
+//! bad performance as "acceptable" defeats the purpose. See bench_plan_tests.rs
+//! for their #[ignore] plan assertions.
+
+use anyhow::Result;
+use eql_tests::{explain_analyze_avg, ExplainStats};
+use sqlx::PgPool;
+
+/// hmac_256 equality must stay under 50ms on 10K rows (expected ~0.5ms)
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
+    let encrypted: String =
+        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE eql_v2.hmac_256(encrypted_text) = eql_v2.hmac_256('{}'::jsonb::eql_v2_encrypted)",
+        encrypted
+    );
+    let stats: ExplainStats = explain_analyze_avg(&pool, &sql, 5).await?;
+    assert!(
+        stats.execution_time_ms < 50.0,
+        "hmac_256 equality took {:.1}ms, threshold 50ms (expected ~0.5ms at 10K rows)",
+        stats.execution_time_ms
+    );
+    Ok(())
+}
+
+/// bloom_filter containment must stay under 100ms on 10K rows (expected ~1ms)
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
+    let encrypted: String =
+        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE eql_v2.bloom_filter(encrypted_text) @> eql_v2.bloom_filter('{}'::jsonb::eql_v2_encrypted)",
+        encrypted
+    );
+    let stats: ExplainStats = explain_analyze_avg(&pool, &sql, 5).await?;
+    assert!(
+        stats.execution_time_ms < 100.0,
+        "bloom_filter containment took {:.1}ms, threshold 100ms (expected ~1ms at 10K rows)",
+        stats.execution_time_ms
+    );
+    Ok(())
+}
+
+/// ORE range query (< LIMIT 10) must stay under 200ms on 10K rows (expected ~2ms)
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
+    let encrypted: String =
+        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 50")
+            .fetch_one(&pool)
+            .await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_int < '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        encrypted
+    );
+    let stats: ExplainStats = explain_analyze_avg(&pool, &sql, 5).await?;
+    assert!(
+        stats.execution_time_ms < 200.0,
+        "ORE range < LIMIT 10 took {:.1}ms, threshold 200ms (expected ~2ms at 10K rows)",
+        stats.execution_time_ms
+    );
+    Ok(())
+}
+
+/// ORE ORDER BY LIMIT 10 must stay under 2000ms on 10K rows
+///
+/// The design doc's observed baseline for this pattern is ~543ms at 10K rows
+/// ("Full-set comparison before sort"). Threshold is set at 2000ms — 4x the
+/// observed baseline — to absorb CI variance while catching catastrophic regressions.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn ore_order_by_under_threshold(pool: PgPool) -> Result<()> {
+    let stats: ExplainStats =
+        explain_analyze_avg(&pool, "SELECT * FROM bench ORDER BY encrypted_int LIMIT 10", 5)
+            .await?;
+    assert!(
+        stats.execution_time_ms < 2000.0,
+        "ORE ORDER BY LIMIT 10 took {:.1}ms, threshold 2000ms (observed ~543ms baseline at 10K rows)",
+        stats.execution_time_ms
+    );
+    Ok(())
+}

--- a/tests/sqlx/tests/bench_regression_tests.rs
+++ b/tests/sqlx/tests/bench_regression_tests.rs
@@ -1,7 +1,9 @@
 //! Tier 1 benchmark magnitude regression tests
 //!
-//! Asserts execution time stays under generous thresholds (~100x expected)
-//! to catch catastrophic regressions while tolerating CI runner variance.
+//! Asserts execution time stays under generous thresholds to catch catastrophic regressions
+//! while tolerating CI runner variance. Most thresholds are ~100x the expected baseline;
+//! ore_order_by uses 4x (543ms observed baseline leaves little headroom for a 100x multiple
+//! without creating a test that never fails).
 //! Uses EXPLAIN ANALYZE averaged over 5 runs for server-side timing.
 //!
 //! Patterns known to be broken (P0 seq scans) are NOT included here — encoding
@@ -9,16 +11,14 @@
 //! for their #[ignore] plan assertions.
 
 use anyhow::Result;
-use eql_tests::{explain_analyze_avg, ExplainStats};
+use eql_tests::{explain_analyze_avg, get_bench_encrypted_int, get_bench_encrypted_text, ExplainStats};
 use sqlx::PgPool;
 
 /// hmac_256 equality must stay under 50ms on 10K rows (expected ~0.5ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
-            .fetch_one(&pool)
-            .await?;
+    // id=1 maps to 1 of 100 distinct values → ~100 matching rows at 10K
+    let encrypted = get_bench_encrypted_text(&pool, 1).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE eql_v2.hmac_256(encrypted_text) = eql_v2.hmac_256('{}'::jsonb::eql_v2_encrypted)",
@@ -27,8 +27,8 @@ async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
     let stats: ExplainStats = explain_analyze_avg(&pool, &sql, 5).await?;
     assert!(
         stats.execution_time_ms < 50.0,
-        "hmac_256 equality took {:.1}ms, threshold 50ms (expected ~0.5ms at 10K rows)",
-        stats.execution_time_ms
+        "hmac_256 equality took {:.1}ms, threshold 50ms (expected ~0.5ms at 10K rows, node_type={})",
+        stats.execution_time_ms, stats.node_type
     );
     Ok(())
 }
@@ -36,10 +36,8 @@ async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
 /// bloom_filter containment must stay under 100ms on 10K rows (expected ~1ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_text).data::text FROM bench WHERE id = 1")
-            .fetch_one(&pool)
-            .await?;
+    // id=1 maps to 1 of 100 distinct values → ~100 matching rows at 10K
+    let encrypted = get_bench_encrypted_text(&pool, 1).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE eql_v2.bloom_filter(encrypted_text) @> eql_v2.bloom_filter('{}'::jsonb::eql_v2_encrypted)",
@@ -48,8 +46,8 @@ async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
     let stats: ExplainStats = explain_analyze_avg(&pool, &sql, 5).await?;
     assert!(
         stats.execution_time_ms < 100.0,
-        "bloom_filter containment took {:.1}ms, threshold 100ms (expected ~1ms at 10K rows)",
-        stats.execution_time_ms
+        "bloom_filter containment took {:.1}ms, threshold 100ms (expected ~1ms at 10K rows, node_type={})",
+        stats.execution_time_ms, stats.node_type
     );
     Ok(())
 }
@@ -57,20 +55,19 @@ async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
 /// ORE range query (< LIMIT 10) must stay under 200ms on 10K rows (expected ~2ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
-    let encrypted: String =
-        sqlx::query_scalar("SELECT (encrypted_int).data::text FROM bench WHERE id = 50")
-            .fetch_one(&pool)
-            .await?;
+    // id=50 is the distribution midpoint → ~4,900 rows below threshold
+    let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
     let sql = format!(
-        "SELECT * FROM bench WHERE encrypted_int < '{}'::jsonb::eql_v2_encrypted ORDER BY encrypted_int LIMIT 10",
+        "SELECT * FROM bench WHERE encrypted_int < '{}'::jsonb::eql_v2_encrypted \
+         ORDER BY encrypted_int LIMIT 10",
         encrypted
     );
     let stats: ExplainStats = explain_analyze_avg(&pool, &sql, 5).await?;
     assert!(
         stats.execution_time_ms < 200.0,
-        "ORE range < LIMIT 10 took {:.1}ms, threshold 200ms (expected ~2ms at 10K rows)",
-        stats.execution_time_ms
+        "ORE range < LIMIT 10 took {:.1}ms, threshold 200ms (expected ~2ms at 10K rows, node_type={})",
+        stats.execution_time_ms, stats.node_type
     );
     Ok(())
 }
@@ -87,8 +84,8 @@ async fn ore_order_by_under_threshold(pool: PgPool) -> Result<()> {
             .await?;
     assert!(
         stats.execution_time_ms < 2000.0,
-        "ORE ORDER BY LIMIT 10 took {:.1}ms, threshold 2000ms (observed ~543ms baseline at 10K rows)",
-        stats.execution_time_ms
+        "ORE ORDER BY LIMIT 10 took {:.1}ms, threshold 2000ms (observed ~543ms baseline at 10K rows, node_type={})",
+        stats.execution_time_ms, stats.node_type
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Index performance benchmark test suite.

- `fixtures/bench_data.sql` + `bench_setup.sql` — 10K-row benchmark table with hmac_256, bloom_filter, and ORE indexes
- `tests/bench_data_tests.rs` — data + index-term verification (12 tests)
- `tests/bench_plan_tests.rs` — EXPLAIN plan / index-usage assertions
- `tests/bench_regression_tests.rs` — EXPLAIN ANALYZE timing thresholds: hmac_256 `=` <50ms, bloom_filter `@>` <100ms, ORE range <200ms, ORE ORDER BY <2000ms
- Shared helpers (`explain_analyze_avg`, `assert_uses_index`, `ExplainStats`, `get_bench_encrypted_*`) in `eql_tests`

Two plan tests `#[ignore]`'d under CIP-2831: eql_cast equality and ORE equality via operator class both fall back to seq scan.

## Test plan

- [ ] `bench_data_tests`: 12 pass
- [ ] `bench_plan_tests`: 3 pass, 2 ignored (CIP-2831)
- [ ] `bench_regression_tests`: 4 pass