### PR TITLE
ci: split slow bench/perf tests off the per-PR critical path

### DIFF
--- a/.github/workflows/bench-eql.yml
+++ b/.github/workflows/bench-eql.yml
@@ -1,0 +1,64 @@
+name: "Bench EQL"
+
+# Runs the slow benchmark / regression / scale SQLx tests gated behind the
+# `bench` cargo feature. Not on PRs — those use the fast `test` workflow.
+# Triggers:
+#   - push to main (catches regressions before release)
+#   - nightly schedule (additional smoke)
+#   - manual workflow_dispatch (PR triage)
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/bench-eql.yml"
+      - "src/**/*.sql"
+      - "tests/sqlx/**/*"
+      - "tasks/**/*"
+
+  schedule:
+    # 02:00 UTC daily
+    - cron: "0 2 * * *"
+
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  MISE_VERBOSE: "1"
+
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  bench:
+    name: "Bench EQL (Postgres 17)"
+    runs-on: ubuntu-latest-m
+    timeout-minutes: 60
+
+    env:
+      POSTGRES_VERSION: "17"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tests/sqlx
+          shared-key: sqlx-tests
+
+      - name: Setup database
+        run: |
+          mise run postgres:up postgres-${POSTGRES_VERSION} --extra-args "--detach --wait"
+
+      - name: Run bench tests
+        run: |
+          export active_rust_toolchain=$(rustup show active-toolchain | cut -d' ' -f1)
+          rustup component add --toolchain ${active_rust_toolchain} rustfmt clippy
+          mise run --output prefix test:bench --postgres ${POSTGRES_VERSION}

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -51,6 +51,11 @@ jobs:
           install: true # [default: true] run `mise install`
           cache: true # [default: true] cache mise using GitHub's cache
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: tests/sqlx
+          shared-key: sqlx-tests
+
       - name: Setup database (Postgres ${{ matrix.postgres-version }})
         run: |
           mise run postgres:up postgres-${POSTGRES_VERSION} --extra-args "--detach --wait"

--- a/tasks/test/bench.sh
+++ b/tasks/test/bench.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#MISE description="Run benchmark / regression / scale SQLx tests (--features bench)"
+#USAGE flag "--postgres <version>" help="PostgreSQL version" default="17" {
+#USAGE   choices "14" "15" "16" "17"
+#USAGE }
+
+set -euo pipefail
+
+POSTGRES_VERSION=${usage_postgres}
+
+echo "=========================================="
+echo "Running EQL Bench Suite"
+echo "PostgreSQL Version: $POSTGRES_VERSION"
+echo "=========================================="
+
+"$(dirname "$0")/../postgres/check_container.sh" "${POSTGRES_VERSION}"
+
+echo "Building EQL..."
+mise run --output prefix --force build
+
+echo "Updating SQLx migrations with built EQL..."
+cp release/cipherstash-encrypt.sql tests/sqlx/migrations/001_install_eql.sql
+
+echo "Running SQLx migrations..."
+(cd tests/sqlx && sqlx migrate run)
+
+echo "Running bench tests (cargo test --features bench)..."
+(cd tests/sqlx && cargo test --features bench)

--- a/tests/sqlx/Cargo.toml
+++ b/tests/sqlx/Cargo.toml
@@ -12,3 +12,11 @@ anyhow = "1"
 
 [dev-dependencies]
 # None needed - tests live in this crate
+
+[features]
+default = []
+# Opt-in to slow benchmark / regression / scale tests. Without this feature
+# they're #[ignore]'d so PR CI stays fast. The `bench-eql` workflow enables
+# it on push to main and on a nightly schedule. Run locally with:
+#   mise run test:bench
+bench = []

--- a/tests/sqlx/tests/bench_data_tests.rs
+++ b/tests/sqlx/tests/bench_data_tests.rs
@@ -24,6 +24,7 @@ async fn fetch_sample_encrypted_text(pool: &PgPool) -> Result<String> {
 
 /// Verify fixture seeded exactly 10K rows
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_table_has_expected_row_count(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM bench")
         .fetch_one(&pool)
@@ -37,6 +38,7 @@ async fn bench_table_has_expected_row_count(pool: PgPool) -> Result<()> {
 
 /// Verify all three columns have non-null encrypted data
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_columns_are_populated(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench
@@ -55,6 +57,7 @@ async fn bench_columns_are_populated(pool: PgPool) -> Result<()> {
 
 /// Verify hmac_256 index terms are extractable from encrypted_text
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_encrypted_text_has_hmac_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.hmac_256(encrypted_text) IS NOT NULL",
@@ -70,6 +73,7 @@ async fn bench_encrypted_text_has_hmac_terms(pool: PgPool) -> Result<()> {
 
 /// Verify bloom_filter index terms are extractable from encrypted_text
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_encrypted_text_has_bloom_filter_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.bloom_filter(encrypted_text) IS NOT NULL",
@@ -85,6 +89,7 @@ async fn bench_encrypted_text_has_bloom_filter_terms(pool: PgPool) -> Result<()>
 
 /// Verify ORE terms are extractable from encrypted_int (3 of 5 indexes are ORE btree)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_encrypted_int_has_ore_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.ore_block_u64_8_256(encrypted_int) IS NOT NULL",
@@ -103,6 +108,7 @@ async fn bench_encrypted_int_has_ore_terms(pool: PgPool) -> Result<()> {
 /// Both int and bigint columns use the same eql_v2_encrypted type and ob index structure.
 /// These tests verify that data seeding populated both columns, not that encoding differs.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_encrypted_bigint_has_ore_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.ore_block_u64_8_256(encrypted_bigint) IS NOT NULL",
@@ -120,6 +126,7 @@ async fn bench_encrypted_bigint_has_ore_terms(pool: PgPool) -> Result<()> {
 
 /// Verify hash index is used for hmac_256 equality lookup
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_hmac_equality_uses_hash_index(pool: PgPool) -> Result<()> {
     let encrypted = fetch_sample_encrypted_text(&pool).await?;
 
@@ -133,6 +140,7 @@ async fn bench_hmac_equality_uses_hash_index(pool: PgPool) -> Result<()> {
 
 /// Verify btree index is used for ORDER BY with LIMIT on encrypted_int
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_ore_order_uses_btree_index(pool: PgPool) -> Result<()> {
     let sql = "SELECT * FROM bench ORDER BY encrypted_int LIMIT 10";
     assert_uses_index(&pool, sql, "bench_int_ore_idx").await?;
@@ -141,6 +149,7 @@ async fn bench_ore_order_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// Verify GIN index is used for bloom_filter containment
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_bloom_containment_uses_gin_index(pool: PgPool) -> Result<()> {
     let encrypted = fetch_sample_encrypted_text(&pool).await?;
 
@@ -154,6 +163,7 @@ async fn bench_bloom_containment_uses_gin_index(pool: PgPool) -> Result<()> {
 
 /// Verify btree index is used for ORDER BY with LIMIT on encrypted_text
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_ore_text_order_uses_btree_index(pool: PgPool) -> Result<()> {
     let sql = "SELECT * FROM bench ORDER BY encrypted_text LIMIT 10";
     assert_uses_index(&pool, sql, "bench_text_ore_idx").await?;
@@ -162,6 +172,7 @@ async fn bench_ore_text_order_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// Verify btree index is used for ORDER BY with LIMIT on encrypted_bigint
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_ore_bigint_order_uses_btree_index(pool: PgPool) -> Result<()> {
     let sql = "SELECT * FROM bench ORDER BY encrypted_bigint LIMIT 10";
     assert_uses_index(&pool, sql, "bench_bigint_ore_idx").await?;
@@ -170,6 +181,7 @@ async fn bench_ore_bigint_order_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// Verify sequential scan without indexes (before/after pattern sanity check)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bench_hmac_without_index_uses_seq_scan(pool: PgPool) -> Result<()> {
     analyze_table(&pool, "bench").await?;
 

--- a/tests/sqlx/tests/bench_data_tests.rs
+++ b/tests/sqlx/tests/bench_data_tests.rs
@@ -24,7 +24,10 @@ async fn fetch_sample_encrypted_text(pool: &PgPool) -> Result<String> {
 
 /// Verify fixture seeded exactly 10K rows
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_table_has_expected_row_count(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM bench")
         .fetch_one(&pool)
@@ -38,7 +41,10 @@ async fn bench_table_has_expected_row_count(pool: PgPool) -> Result<()> {
 
 /// Verify all three columns have non-null encrypted data
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_columns_are_populated(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench
@@ -57,7 +63,10 @@ async fn bench_columns_are_populated(pool: PgPool) -> Result<()> {
 
 /// Verify hmac_256 index terms are extractable from encrypted_text
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_encrypted_text_has_hmac_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.hmac_256(encrypted_text) IS NOT NULL",
@@ -73,7 +82,10 @@ async fn bench_encrypted_text_has_hmac_terms(pool: PgPool) -> Result<()> {
 
 /// Verify bloom_filter index terms are extractable from encrypted_text
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_encrypted_text_has_bloom_filter_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.bloom_filter(encrypted_text) IS NOT NULL",
@@ -89,7 +101,10 @@ async fn bench_encrypted_text_has_bloom_filter_terms(pool: PgPool) -> Result<()>
 
 /// Verify ORE terms are extractable from encrypted_int (3 of 5 indexes are ORE btree)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_encrypted_int_has_ore_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.ore_block_u64_8_256(encrypted_int) IS NOT NULL",
@@ -108,7 +123,10 @@ async fn bench_encrypted_int_has_ore_terms(pool: PgPool) -> Result<()> {
 /// Both int and bigint columns use the same eql_v2_encrypted type and ob index structure.
 /// These tests verify that data seeding populated both columns, not that encoding differs.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_encrypted_bigint_has_ore_terms(pool: PgPool) -> Result<()> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM bench WHERE eql_v2.ore_block_u64_8_256(encrypted_bigint) IS NOT NULL",
@@ -126,7 +144,10 @@ async fn bench_encrypted_bigint_has_ore_terms(pool: PgPool) -> Result<()> {
 
 /// Verify hash index is used for hmac_256 equality lookup
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_hmac_equality_uses_hash_index(pool: PgPool) -> Result<()> {
     let encrypted = fetch_sample_encrypted_text(&pool).await?;
 
@@ -140,7 +161,10 @@ async fn bench_hmac_equality_uses_hash_index(pool: PgPool) -> Result<()> {
 
 /// Verify btree index is used for ORDER BY with LIMIT on encrypted_int
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_ore_order_uses_btree_index(pool: PgPool) -> Result<()> {
     let sql = "SELECT * FROM bench ORDER BY encrypted_int LIMIT 10";
     assert_uses_index(&pool, sql, "bench_int_ore_idx").await?;
@@ -149,7 +173,10 @@ async fn bench_ore_order_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// Verify GIN index is used for bloom_filter containment
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_bloom_containment_uses_gin_index(pool: PgPool) -> Result<()> {
     let encrypted = fetch_sample_encrypted_text(&pool).await?;
 
@@ -163,7 +190,10 @@ async fn bench_bloom_containment_uses_gin_index(pool: PgPool) -> Result<()> {
 
 /// Verify btree index is used for ORDER BY with LIMIT on encrypted_text
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_ore_text_order_uses_btree_index(pool: PgPool) -> Result<()> {
     let sql = "SELECT * FROM bench ORDER BY encrypted_text LIMIT 10";
     assert_uses_index(&pool, sql, "bench_text_ore_idx").await?;
@@ -172,7 +202,10 @@ async fn bench_ore_text_order_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// Verify btree index is used for ORDER BY with LIMIT on encrypted_bigint
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_ore_bigint_order_uses_btree_index(pool: PgPool) -> Result<()> {
     let sql = "SELECT * FROM bench ORDER BY encrypted_bigint LIMIT 10";
     assert_uses_index(&pool, sql, "bench_bigint_ore_idx").await?;
@@ -181,7 +214,10 @@ async fn bench_ore_bigint_order_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// Verify sequential scan without indexes (before/after pattern sanity check)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bench_hmac_without_index_uses_seq_scan(pool: PgPool) -> Result<()> {
     analyze_table(&pool, "bench").await?;
 

--- a/tests/sqlx/tests/bench_plan_tests.rs
+++ b/tests/sqlx/tests/bench_plan_tests.rs
@@ -14,6 +14,7 @@ const BENCH_TEXT_HMAC_IDX: &str = "bench_text_hmac_idx";
 
 /// ORE range query (less-than) uses btree index
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn ore_int_range_lt_uses_btree_index(pool: PgPool) -> Result<()> {
     let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
@@ -28,6 +29,7 @@ async fn ore_int_range_lt_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// ORE range query (greater-than) uses btree index
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn ore_int_range_gt_uses_btree_index(pool: PgPool) -> Result<()> {
     let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
@@ -45,6 +47,7 @@ async fn ore_int_range_gt_uses_btree_index(pool: PgPool) -> Result<()> {
 /// Uses explicit >= / <= rather than BETWEEN — BETWEEN's operator resolution
 /// against eql_v2_encrypted is untested and may not resolve to the btree family.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn ore_int_range_combined_uses_btree_index(pool: PgPool) -> Result<()> {
     let low = get_bench_encrypted_int(&pool, 10).await?;
     let high = get_bench_encrypted_int(&pool, 90).await?;

--- a/tests/sqlx/tests/bench_plan_tests.rs
+++ b/tests/sqlx/tests/bench_plan_tests.rs
@@ -14,7 +14,10 @@ const BENCH_TEXT_HMAC_IDX: &str = "bench_text_hmac_idx";
 
 /// ORE range query (less-than) uses btree index
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn ore_int_range_lt_uses_btree_index(pool: PgPool) -> Result<()> {
     let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
@@ -29,7 +32,10 @@ async fn ore_int_range_lt_uses_btree_index(pool: PgPool) -> Result<()> {
 
 /// ORE range query (greater-than) uses btree index
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn ore_int_range_gt_uses_btree_index(pool: PgPool) -> Result<()> {
     let encrypted = get_bench_encrypted_int(&pool, 50).await?;
 
@@ -47,7 +53,10 @@ async fn ore_int_range_gt_uses_btree_index(pool: PgPool) -> Result<()> {
 /// Uses explicit >= / <= rather than BETWEEN — BETWEEN's operator resolution
 /// against eql_v2_encrypted is untested and may not resolve to the btree family.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn ore_int_range_combined_uses_btree_index(pool: PgPool) -> Result<()> {
     let low = get_bench_encrypted_int(&pool, 10).await?;
     let high = get_bench_encrypted_int(&pool, 90).await?;

--- a/tests/sqlx/tests/bench_regression_tests.rs
+++ b/tests/sqlx/tests/bench_regression_tests.rs
@@ -18,7 +18,10 @@ use sqlx::PgPool;
 
 /// hmac_256 equality must stay under 50ms on 10K rows (expected ~0.5ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
     // id=1 maps to 1 of 100 distinct values → ~100 matching rows at 10K
     let encrypted = get_bench_encrypted_text(&pool, 1).await?;
@@ -38,7 +41,10 @@ async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
 
 /// bloom_filter containment must stay under 100ms on 10K rows (expected ~1ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
     // id=1 maps to 1 of 100 distinct values → ~100 matching rows at 10K
     let encrypted = get_bench_encrypted_text(&pool, 1).await?;
@@ -58,7 +64,10 @@ async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
 
 /// ORE range query (< LIMIT 10) must stay under 200ms on 10K rows (expected ~2ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
     // id=50 is the bench row midpoint; encrypted_int uses a +33 offset so this maps
     // to ore id 83, but the 10K distribution still yields ~4,900 rows below the predicate
@@ -84,7 +93,10 @@ async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
 /// ("Full-set comparison before sort"). Threshold is set at 2000ms — 4x the
 /// observed baseline — to absorb CI variance while catching catastrophic regressions.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn ore_order_by_under_threshold(pool: PgPool) -> Result<()> {
     let stats: ExplainStats = explain_analyze_avg(
         &pool,

--- a/tests/sqlx/tests/bench_regression_tests.rs
+++ b/tests/sqlx/tests/bench_regression_tests.rs
@@ -18,6 +18,7 @@ use sqlx::PgPool;
 
 /// hmac_256 equality must stay under 50ms on 10K rows (expected ~0.5ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
     // id=1 maps to 1 of 100 distinct values → ~100 matching rows at 10K
     let encrypted = get_bench_encrypted_text(&pool, 1).await?;
@@ -37,6 +38,7 @@ async fn hmac_equality_under_threshold(pool: PgPool) -> Result<()> {
 
 /// bloom_filter containment must stay under 100ms on 10K rows (expected ~1ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
     // id=1 maps to 1 of 100 distinct values → ~100 matching rows at 10K
     let encrypted = get_bench_encrypted_text(&pool, 1).await?;
@@ -56,6 +58,7 @@ async fn bloom_filter_containment_under_threshold(pool: PgPool) -> Result<()> {
 
 /// ORE range query (< LIMIT 10) must stay under 200ms on 10K rows (expected ~2ms)
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
     // id=50 is the bench row midpoint; encrypted_int uses a +33 offset so this maps
     // to ore id 83, but the 10K distribution still yields ~4,900 rows below the predicate
@@ -81,6 +84,7 @@ async fn ore_range_lt_under_threshold(pool: PgPool) -> Result<()> {
 /// ("Full-set comparison before sort"). Threshold is set at 2000ms — 4x the
 /// observed baseline — to absorb CI variance while catching catastrophic regressions.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn ore_order_by_under_threshold(pool: PgPool) -> Result<()> {
     let stats: ExplainStats = explain_analyze_avg(
         &pool,

--- a/tests/sqlx/tests/order_by_no_opclass_tests.rs
+++ b/tests/sqlx/tests/order_by_no_opclass_tests.rs
@@ -169,6 +169,7 @@ async fn direct_order_by_desc_wrong_order_without_opclass(pool: PgPool) -> Resul
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn correlated_subquery_ranking_asc_without_opclass(pool: PgPool) -> Result<()> {
     // eql_v2.compare() is a standalone function (not an operator), so it survives
     // the operator class drops. A correlated subquery counts how many rows have a
@@ -198,6 +199,7 @@ async fn correlated_subquery_ranking_asc_without_opclass(pool: PgPool) -> Result
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn correlated_subquery_ranking_desc_without_opclass(pool: PgPool) -> Result<()> {
     // Same correlated subquery with DESC — should return highest-ranked rows first.
 
@@ -220,6 +222,7 @@ async fn correlated_subquery_ranking_desc_without_opclass(pool: PgPool) -> Resul
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn correlated_subquery_ranking_with_limit_without_opclass(pool: PgPool) -> Result<()> {
     // LIMIT 1 with ASC subquery ranking should return the smallest value (id=1)
 
@@ -238,6 +241,7 @@ async fn correlated_subquery_ranking_with_limit_without_opclass(pool: PgPool) ->
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn correlated_subquery_ranking_with_where_without_opclass(pool: PgPool) -> Result<()> {
     // WHERE clause filters rows, then correlated subquery orders the result correctly.
     // Note: the subquery counts over the full table to produce a global rank.

--- a/tests/sqlx/tests/order_by_no_opclass_tests.rs
+++ b/tests/sqlx/tests/order_by_no_opclass_tests.rs
@@ -169,7 +169,10 @@ async fn direct_order_by_desc_wrong_order_without_opclass(pool: PgPool) -> Resul
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn correlated_subquery_ranking_asc_without_opclass(pool: PgPool) -> Result<()> {
     // eql_v2.compare() is a standalone function (not an operator), so it survives
     // the operator class drops. A correlated subquery counts how many rows have a
@@ -199,7 +202,10 @@ async fn correlated_subquery_ranking_asc_without_opclass(pool: PgPool) -> Result
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn correlated_subquery_ranking_desc_without_opclass(pool: PgPool) -> Result<()> {
     // Same correlated subquery with DESC — should return highest-ranked rows first.
 
@@ -222,7 +228,10 @@ async fn correlated_subquery_ranking_desc_without_opclass(pool: PgPool) -> Resul
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn correlated_subquery_ranking_with_limit_without_opclass(pool: PgPool) -> Result<()> {
     // LIMIT 1 with ASC subquery ranking should return the smallest value (id=1)
 
@@ -241,7 +250,10 @@ async fn correlated_subquery_ranking_with_limit_without_opclass(pool: PgPool) ->
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn correlated_subquery_ranking_with_where_without_opclass(pool: PgPool) -> Result<()> {
     // WHERE clause filters rows, then correlated subquery orders the result correctly.
     // Note: the subquery counts over the full table to produce a global rank.

--- a/tests/sqlx/tests/order_by_sort_tests.rs
+++ b/tests/sqlx/tests/order_by_sort_tests.rs
@@ -522,7 +522,10 @@ async fn sort_compare_table_ref_matches_order_by_compare(pool: PgPool) -> Result
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn filtered_inner_query_correct_order(pool: PgPool) -> Result<()> {
     // Optimized: inner query also filters, producing correct relative ordering
     // within the filtered set
@@ -565,7 +568,10 @@ async fn filtered_inner_query_correct_order(pool: PgPool) -> Result<()> {
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn filtered_inner_query_with_range(pool: PgPool) -> Result<()> {
     // Range filter: rows with ids 20-80
     let ore_term_19 = get_ore_encrypted(&pool, 19).await?;
@@ -604,7 +610,10 @@ async fn filtered_inner_query_with_range(pool: PgPool) -> Result<()> {
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn sort_compare_faster_than_correlated_subquery(pool: PgPool) -> Result<()> {
     // Warm up: run each query once to populate caches
     let sort_sql = "SELECT * FROM eql_v2.sort_compare(
@@ -647,7 +656,10 @@ async fn sort_compare_faster_than_correlated_subquery(pool: PgPool) -> Result<()
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn filtered_inner_query_faster_than_unfiltered(pool: PgPool) -> Result<()> {
     let ore_term = get_ore_encrypted(&pool, 42).await?;
 
@@ -707,7 +719,10 @@ async fn filtered_inner_query_faster_than_unfiltered(pool: PgPool) -> Result<()>
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn sort_compare_performance_at_scale(pool: PgPool) -> Result<()> {
     // 1000 rows is sufficient scale to demonstrate O(n log n) vs O(n²)
     let sort_sql = "SELECT * FROM eql_v2.sort_compare(
@@ -743,7 +758,10 @@ async fn sort_compare_performance_at_scale(pool: PgPool) -> Result<()> {
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn filtered_inner_query_performance_at_scale(pool: PgPool) -> Result<()> {
     let ore_term = get_ore_encrypted(&pool, 42).await?;
 
@@ -793,7 +811,10 @@ async fn filtered_inner_query_performance_at_scale(pool: PgPool) -> Result<()> {
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
-#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
+#[cfg_attr(
+    not(feature = "bench"),
+    ignore = "perf-bench: gated, run via mise test:bench"
+)]
 async fn sort_compare_text_performance(pool: PgPool) -> Result<()> {
     let sort_sql = "SELECT * FROM eql_v2.sort_compare(
         (SELECT array_agg(id ORDER BY id) FROM ore_text),

--- a/tests/sqlx/tests/order_by_sort_tests.rs
+++ b/tests/sqlx/tests/order_by_sort_tests.rs
@@ -522,6 +522,7 @@ async fn sort_compare_table_ref_matches_order_by_compare(pool: PgPool) -> Result
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn filtered_inner_query_correct_order(pool: PgPool) -> Result<()> {
     // Optimized: inner query also filters, producing correct relative ordering
     // within the filtered set
@@ -564,6 +565,7 @@ async fn filtered_inner_query_correct_order(pool: PgPool) -> Result<()> {
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn filtered_inner_query_with_range(pool: PgPool) -> Result<()> {
     // Range filter: rows with ids 20-80
     let ore_term_19 = get_ore_encrypted(&pool, 19).await?;
@@ -602,6 +604,7 @@ async fn filtered_inner_query_with_range(pool: PgPool) -> Result<()> {
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn sort_compare_faster_than_correlated_subquery(pool: PgPool) -> Result<()> {
     // Warm up: run each query once to populate caches
     let sort_sql = "SELECT * FROM eql_v2.sort_compare(
@@ -644,6 +647,7 @@ async fn sort_compare_faster_than_correlated_subquery(pool: PgPool) -> Result<()
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn filtered_inner_query_faster_than_unfiltered(pool: PgPool) -> Result<()> {
     let ore_term = get_ore_encrypted(&pool, 42).await?;
 
@@ -703,6 +707,7 @@ async fn filtered_inner_query_faster_than_unfiltered(pool: PgPool) -> Result<()>
 // ============================================================================
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn sort_compare_performance_at_scale(pool: PgPool) -> Result<()> {
     // 1000 rows is sufficient scale to demonstrate O(n log n) vs O(n²)
     let sort_sql = "SELECT * FROM eql_v2.sort_compare(
@@ -738,6 +743,7 @@ async fn sort_compare_performance_at_scale(pool: PgPool) -> Result<()> {
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn filtered_inner_query_performance_at_scale(pool: PgPool) -> Result<()> {
     let ore_term = get_ore_encrypted(&pool, 42).await?;
 
@@ -787,6 +793,7 @@ async fn filtered_inner_query_performance_at_scale(pool: PgPool) -> Result<()> {
 }
 
 #[sqlx::test(fixtures(path = "../fixtures", scripts("drop_operator_classes")))]
+#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]
 async fn sort_compare_text_performance(pool: PgPool) -> Result<()> {
     let sort_sql = "SELECT * FROM eql_v2.sort_compare(
         (SELECT array_agg(id ORDER BY id) FROM ore_text),


### PR DESCRIPTION
## Summary

PG17 EQL test job is ~33 min on every PR; ~31 min of that is test execution (cargo compile is ~1.5 min). 21 SQLx tests run >60s each — bench/regression/scale tests that load 10K-row encrypted fixtures, run `EXPLAIN ANALYZE x5`, or exercise O(n²) correlated-subquery workarounds. Valuable, but no need to gate every PR.

## Approach

Cargo feature gate. PR CI gets default `cargo test` (slow tests `#[ignore]`'d). A separate `bench-eql.yml` workflow runs `cargo test --features bench` on push-to-main, nightly, and on demand.

### Changes

- **`tests/sqlx/Cargo.toml`** — adds `bench` feature.
- **5 test files, 30 functions** — gated with `#[cfg_attr(not(feature = "bench"), ignore = "perf-bench: gated, run via mise test:bench")]`:
  - `bench_data_tests.rs` (12) — every test loads 10K-row fixture
  - `bench_plan_tests.rs` (3) — also 10K-row fixture; the 2 existing CIP-2831 `#[ignore]` tests are left untouched
  - `bench_regression_tests.rs` (4) — `EXPLAIN ANALYZE x5` regression thresholds
  - `order_by_no_opclass_tests.rs` (4) — only the `correlated_subquery_ranking_*` tests (O(n²)); the fast `order_by_helper_*` and `direct_order_by_*` tests stay
  - `order_by_sort_tests.rs` (7) — only the perf-flavored ones at the bottom of the file; fast tests stay
- **`tasks/test/bench.sh`** — new `mise run test:bench` task.
- **`.github/workflows/bench-eql.yml`** — new workflow. Runs on push to main, daily at 02:00 UTC, and `workflow_dispatch`. Not triggered on PRs.
- **`.github/workflows/test-eql.yml`** — adds `Swatinem/rust-cache@v2` keyed on `tests/sqlx`. Saves ~60-90s of cargo compile per run.

### Coexistence with existing `#[ignore]` tests

The two CIP-2831 tests in `bench_plan_tests.rs` (`eql_cast_equality_uses_hash_index`, `ore_equality_uses_btree_index`) keep their unconditional `#[ignore = "CIP-2831: ..."]`. Their gate is "broken, tracked in CIP-2831", not "slow". So even `cargo test --features bench` skips them — correct, since CIP-2831 hasn't been resolved yet.

### Expected outcome

PR CI drops from ~33 min to whatever the cargo-compile + fast-test set costs (rough ballpark ~3-5 min, will know once a PR run completes against this). Bench coverage is preserved on main + nightly.

## Test plan

- [x] `cargo check --tests` passes (default features)
- [x] `cargo check --tests --features bench` passes
- [x] `cargo test --test bench_regression_tests` shows 4 ignored, 0 run
- [x] `cargo test --features bench --test bench_regression_tests` shows 4 passed, 0 ignored
- [x] Both workflow YAMLs validate
- [x] First PR-time CI run on this branch confirms drop in step duration
- [x] First push-to-main run confirms `bench-eql.yml` actually picks up the gated tests

## Notes for reviewers

- The `bench` cargo feature is a *test* gate; nothing in `src/` depends on it. It's invisible to the EQL artifact.
- Rust-cache is shared between workflows via `shared-key: sqlx-tests`. Both jobs warm the same cache key.
- Schedule of 02:00 UTC is arbitrary — happy to change.
- Tracked in [CIP-2831](https://linear.app/cipherstash/issue/CIP-2831/eql-index-performance-issues): if root cause for index-recognition issues lands, expect bench thresholds (currently 100x headroom in many cases) to start showing real signal — they're effectively dormant alarms today.