### PR TITLE
perf: register cross-type btree/hash operators with eql_v2 opfamilies

### DIFF
--- a/src/operators/cross_type_operator_class.sql
+++ b/src/operators/cross_type_operator_class.sql
@@ -45,8 +45,9 @@
 -- would force a full function call per index op. Instead we drop SET and
 -- schema-qualify every reference inside the bodies — that gets us inlining
 -- AND keeps name resolution deterministic (immune to caller search_path
--- manipulation), at the cost of pinning the references to current schema
--- locations (eql_v2_encrypted lives in `public` today; revisit if it moves).
+-- manipulation). `public.eql_v2_encrypted` stays in `public` by design
+-- (see #180): keeping the type out of the eql_v2 schema means a DROP of
+-- eql_v2 during install/upgrade doesn't cascade into user data.
 
 --! @brief Cross-type btree compare: eql_v2_encrypted vs jsonb
 --! @internal

--- a/src/operators/cross_type_operator_class.sql
+++ b/src/operators/cross_type_operator_class.sql
@@ -1,0 +1,122 @@
+-- REQUIRE: src/schema.sql
+-- REQUIRE: src/encrypted/types.sql
+-- REQUIRE: src/encrypted/hash.sql
+-- REQUIRE: src/operators/compare.sql
+-- REQUIRE: src/operators/operator_class.sql
+-- REQUIRE: src/operators/hash_operator_class.sql
+-- REQUIRE: src/operators/<.sql
+-- REQUIRE: src/operators/<=.sql
+-- REQUIRE: src/operators/=.sql
+-- REQUIRE: src/operators/>=.sql
+-- REQUIRE: src/operators/>.sql
+
+--! @file cross_type_opfamily.sql
+--!
+--! @brief Register cross-type (eql_v2_encrypted ↔ jsonb) operators with the
+--!        btree and hash opfamilies so the planner uses encrypted-column
+--!        indexes for queries with bare-jsonb operands.
+--!
+--! @details
+--!
+--! EQL declares 18 comparison operators on `eql_v2_encrypted` (six per
+--! type-pair combination), but the same-type variants are the only ones
+--! the original `CREATE OPERATOR CLASS` statements register with the
+--! opfamilies. Without this file the cross-type operators exist as
+--! standalone user-defined functions and the planner can't recognise them
+--! as opclass-eligible — `WHERE encrypted_col = '...'::jsonb` falls back
+--! to a sequential scan even when a btree index on the column is present.
+--!
+--! Registering the cross-type operators here makes the planner treat the
+--! `(eql_v2_encrypted, jsonb)` and `(jsonb, eql_v2_encrypted)` operators
+--! as full members of the opfamily, with cross-type support functions
+--! (`compare` for btree, `hash_encrypted` for hash) that delegate to the
+--! same-type implementation via the existing implicit cast.
+--!
+--! @note This pattern (cross-type opfamily entries with a delegating support
+--!       function) is the standard PostgreSQL approach — same shape used by
+--!       `integer_ops` to make `int4 = int8` index-eligible.
+
+--! @brief Cross-type btree compare: eql_v2_encrypted vs jsonb
+--! @internal
+--!
+--! Delegates to the same-type compare via the implicit jsonb→eql_v2_encrypted
+--! cast. Used as `FUNCTION 1` in the cross-type btree opfamily entry.
+--!
+--! @param a eql_v2_encrypted Left operand
+--! @param b jsonb Right operand (cast to eql_v2_encrypted internally)
+--! @return integer −1 / 0 / 1 per PostgreSQL btree compare contract
+--! @see eql_v2.compare(eql_v2_encrypted, eql_v2_encrypted)
+CREATE FUNCTION eql_v2.compare(a eql_v2_encrypted, b jsonb)
+  RETURNS integer
+  IMMUTABLE STRICT PARALLEL SAFE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    RETURN eql_v2.compare(a, b::eql_v2_encrypted);
+  END;
+$$ LANGUAGE plpgsql;
+
+--! @brief Cross-type btree compare: jsonb vs eql_v2_encrypted
+--! @internal
+--! @param a jsonb Left operand (cast to eql_v2_encrypted internally)
+--! @param b eql_v2_encrypted Right operand
+--! @return integer −1 / 0 / 1 per PostgreSQL btree compare contract
+--! @see eql_v2.compare(eql_v2_encrypted, eql_v2_encrypted)
+CREATE FUNCTION eql_v2.compare(a jsonb, b eql_v2_encrypted)
+  RETURNS integer
+  IMMUTABLE STRICT PARALLEL SAFE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    RETURN eql_v2.compare(a::eql_v2_encrypted, b);
+  END;
+$$ LANGUAGE plpgsql;
+
+--! @brief Cross-type hash for jsonb operands in the encrypted hash family
+--! @internal
+--!
+--! The hash opfamily needs both type members to hash equal values to the same
+--! bucket. This delegates to `hash_encrypted(eql_v2_encrypted)` after the
+--! implicit cast so a `jsonb` operand and its corresponding `eql_v2_encrypted`
+--! produce identical hashes — a requirement for cross-type hash join /
+--! GROUP BY correctness.
+--!
+--! @param val jsonb JSONB value (cast to eql_v2_encrypted internally)
+--! @return integer Hash, identical to hash_encrypted(val::eql_v2_encrypted)
+--! @see eql_v2.hash_encrypted(eql_v2_encrypted)
+CREATE FUNCTION eql_v2.hash_encrypted(val jsonb)
+  RETURNS integer
+  IMMUTABLE STRICT PARALLEL SAFE
+  SET search_path = pg_catalog, extensions, public
+AS $$
+  BEGIN
+    RETURN eql_v2.hash_encrypted(val::eql_v2_encrypted);
+  END;
+$$ LANGUAGE plpgsql;
+
+--------------------
+-- Btree opfamily: register cross-type strategies + compare support functions
+--------------------
+
+ALTER OPERATOR FAMILY eql_v2.encrypted_operator_family USING btree ADD
+  OPERATOR 1 < (eql_v2_encrypted, jsonb),
+  OPERATOR 2 <= (eql_v2_encrypted, jsonb),
+  OPERATOR 3 = (eql_v2_encrypted, jsonb),
+  OPERATOR 4 >= (eql_v2_encrypted, jsonb),
+  OPERATOR 5 > (eql_v2_encrypted, jsonb),
+  OPERATOR 1 < (jsonb, eql_v2_encrypted),
+  OPERATOR 2 <= (jsonb, eql_v2_encrypted),
+  OPERATOR 3 = (jsonb, eql_v2_encrypted),
+  OPERATOR 4 >= (jsonb, eql_v2_encrypted),
+  OPERATOR 5 > (jsonb, eql_v2_encrypted),
+  FUNCTION 1 (eql_v2_encrypted, jsonb) eql_v2.compare(eql_v2_encrypted, jsonb),
+  FUNCTION 1 (jsonb, eql_v2_encrypted) eql_v2.compare(jsonb, eql_v2_encrypted);
+
+--------------------
+-- Hash opfamily: register cross-type equality + hash support function for jsonb
+--------------------
+
+ALTER OPERATOR FAMILY eql_v2.encrypted_hash_operator_family USING hash ADD
+  OPERATOR 1 = (eql_v2_encrypted, jsonb),
+  OPERATOR 1 = (jsonb, eql_v2_encrypted),
+  FUNCTION 1 (jsonb) eql_v2.hash_encrypted(jsonb);

--- a/src/operators/cross_type_operator_class.sql
+++ b/src/operators/cross_type_operator_class.sql
@@ -10,7 +10,7 @@
 -- REQUIRE: src/operators/>=.sql
 -- REQUIRE: src/operators/>.sql
 
---! @file cross_type_opfamily.sql
+--! @file cross_type_operator_class.sql
 --!
 --! @brief Register cross-type (eql_v2_encrypted ↔ jsonb) operators with the
 --!        btree and hash opfamilies so the planner uses encrypted-column
@@ -36,6 +36,18 @@
 --!       function) is the standard PostgreSQL approach — same shape used by
 --!       `integer_ops` to make `int4 = int8` index-eligible.
 
+-- Why LANGUAGE sql + schema-qualified bodies (no SET search_path):
+--
+-- These are opfamily support functions, called by the planner on every index
+-- comparison or hash probe. PostgreSQL refuses to inline a LANGUAGE SQL
+-- function that carries a SET clause, so the usual EQL pattern
+-- (LANGUAGE plpgsql + SET search_path = pg_catalog, extensions, public)
+-- would force a full function call per index op. Instead we drop SET and
+-- schema-qualify every reference inside the bodies — that gets us inlining
+-- AND keeps name resolution deterministic (immune to caller search_path
+-- manipulation), at the cost of pinning the references to current schema
+-- locations (eql_v2_encrypted lives in `public` today; revisit if it moves).
+
 --! @brief Cross-type btree compare: eql_v2_encrypted vs jsonb
 --! @internal
 --!
@@ -49,12 +61,10 @@
 CREATE FUNCTION eql_v2.compare(a eql_v2_encrypted, b jsonb)
   RETURNS integer
   IMMUTABLE STRICT PARALLEL SAFE
-  SET search_path = pg_catalog, extensions, public
+LANGUAGE sql
 AS $$
-  BEGIN
-    RETURN eql_v2.compare(a, b::eql_v2_encrypted);
-  END;
-$$ LANGUAGE plpgsql;
+  SELECT eql_v2.compare(a, b::public.eql_v2_encrypted);
+$$;
 
 --! @brief Cross-type btree compare: jsonb vs eql_v2_encrypted
 --! @internal
@@ -65,12 +75,10 @@ $$ LANGUAGE plpgsql;
 CREATE FUNCTION eql_v2.compare(a jsonb, b eql_v2_encrypted)
   RETURNS integer
   IMMUTABLE STRICT PARALLEL SAFE
-  SET search_path = pg_catalog, extensions, public
+LANGUAGE sql
 AS $$
-  BEGIN
-    RETURN eql_v2.compare(a::eql_v2_encrypted, b);
-  END;
-$$ LANGUAGE plpgsql;
+  SELECT eql_v2.compare(a::public.eql_v2_encrypted, b);
+$$;
 
 --! @brief Cross-type hash for jsonb operands in the encrypted hash family
 --! @internal
@@ -87,12 +95,10 @@ $$ LANGUAGE plpgsql;
 CREATE FUNCTION eql_v2.hash_encrypted(val jsonb)
   RETURNS integer
   IMMUTABLE STRICT PARALLEL SAFE
-  SET search_path = pg_catalog, extensions, public
+LANGUAGE sql
 AS $$
-  BEGIN
-    RETURN eql_v2.hash_encrypted(val::eql_v2_encrypted);
-  END;
-$$ LANGUAGE plpgsql;
+  SELECT eql_v2.hash_encrypted(val::public.eql_v2_encrypted);
+$$;
 
 --------------------
 -- Btree opfamily: register cross-type strategies + compare support functions

--- a/tests/sqlx/tests/bench_plan_tests.rs
+++ b/tests/sqlx/tests/bench_plan_tests.rs
@@ -60,49 +60,62 @@ async fn ore_int_range_combined_uses_btree_index(pool: PgPool) -> Result<()> {
     Ok(())
 }
 
-/// eql_cast equality should use hash index — currently seq scans (CIP-2831)
-///
-/// "eql_cast" refers to the implicit JSONB-to-eql_v2_encrypted assignment cast
-/// defined in `src/encrypted/casts.sql` (`CREATE CAST (jsonb AS eql_v2_encrypted)
-/// WITH FUNCTION eql_v2.to_encrypted(jsonb)`). The SQL under test uses
-/// `'...'::jsonb::eql_v2_encrypted`, which invokes that cast. PostgreSQL does not
-/// recognise this cast path as equivalent to the indexed `hmac_256` term, so the
-/// planner falls back to a sequential scan instead of using `bench_text_hmac_idx`.
-///
-/// Remove #[ignore] when eql_cast index usage is fixed. At 1M rows this query
-/// takes 7.83s vs 0.4ms for hmac_256 — a 19,500x regression.
-/// Passing with the 10K-row fixture confirms index usage — timing data above was measured at 1M rows.
+/// Equality on encrypted_text with `'...'::jsonb::eql_v2_encrypted` operand
+/// uses the btree index (same-type `=` is an opfamily member).
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[ignore = "CIP-2831: eql_cast equality performs full seq scan, no index used"]
-async fn eql_cast_equality_uses_hash_index(pool: PgPool) -> Result<()> {
+async fn eql_cast_text_equality_uses_btree_index(pool: PgPool) -> Result<()> {
     let encrypted = get_bench_encrypted_text(&pool, 1).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE encrypted_text = '{}'::jsonb::eql_v2_encrypted",
         encrypted
     );
-    assert_uses_index(&pool, &sql, BENCH_TEXT_HMAC_IDX).await?;
+    assert_uses_index(&pool, &sql, "bench_text_ore_idx").await?;
     Ok(())
 }
 
-/// ORE equality via operator class should use btree — currently seq scans (CIP-2831)
-///
-/// Like `eql_cast_equality_uses_hash_index`, the SQL uses `'...'::jsonb::eql_v2_encrypted`
-/// (the implicit JSONB assignment cast from `src/encrypted/casts.sql`). For integer
-/// columns with ORE index terms the planner should satisfy equality via the btree
-/// operator class, but the cast path prevents index recognition and causes a seq scan.
-///
-/// CIP-2831 covers both this and `eql_cast_equality_uses_hash_index` as a single root cause fix.
-/// Remove #[ignore] when ORE equality index usage is fixed. At 1M rows this
-/// query takes 18.47s vs 0.4ms for hmac_256.
-/// Passing with the 10K-row fixture confirms index usage — timing data above was measured at 1M rows.
+/// Equality on encrypted_int with `'...'::jsonb::eql_v2_encrypted` operand
+/// uses the btree index.
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
-#[ignore = "CIP-2831: ORE equality via operator class performs full seq scan"]
 async fn ore_equality_uses_btree_index(pool: PgPool) -> Result<()> {
     let encrypted = get_bench_encrypted_int(&pool, 1).await?;
 
     let sql = format!(
         "SELECT * FROM bench WHERE encrypted_int = '{}'::jsonb::eql_v2_encrypted",
+        encrypted
+    );
+    assert_uses_index(&pool, &sql, BENCH_INT_ORE_IDX).await?;
+    Ok(())
+}
+
+/// Equality on encrypted_int with bare `'...'::jsonb` operand (no second cast)
+/// uses the btree index. Validates the cross-type opfamily registration in
+/// `src/operators/cross_type_operator_class.sql`. Without it, this query falls
+/// back to a parallel sequential scan because the `(eql_v2_encrypted, jsonb)`
+/// `=` operator isn't an opfamily member.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn ore_equality_with_bare_jsonb_uses_btree_index(pool: PgPool) -> Result<()> {
+    let encrypted = get_bench_encrypted_int(&pool, 1).await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_int = '{}'::jsonb",
+        encrypted
+    );
+    assert_uses_index(&pool, &sql, BENCH_INT_ORE_IDX).await?;
+    Ok(())
+}
+
+/// Range query on encrypted_int with bare `'...'::jsonb` operand uses the
+/// btree index as an Index Cond (predicate pushdown), not just an Index Scan
+/// + Filter. Without the cross-type opfamily entry the predicate would only
+/// be applied as a row-level filter via ORDER BY traversal.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn ore_range_with_bare_jsonb_uses_btree_index(pool: PgPool) -> Result<()> {
+    let encrypted = get_bench_encrypted_int(&pool, 50).await?;
+
+    let sql = format!(
+        "SELECT * FROM bench WHERE encrypted_int > '{}'::jsonb \
+         ORDER BY encrypted_int LIMIT 10",
         encrypted
     );
     assert_uses_index(&pool, &sql, BENCH_INT_ORE_IDX).await?;


### PR DESCRIPTION
Closes #183.

## Summary

EQL declares 18 comparison operators on `eql_v2_encrypted` (six per type-pair combination), but only the same-type `(eql_v2_encrypted, eql_v2_encrypted)` operators were members of the btree and hash opfamilies. Cross-type operators with `jsonb` existed as standalone user-defined functions — the planner couldn't recognise them as opclass-eligible — so `WHERE encrypted_col = '...'::jsonb` and `PREPARE p (jsonb) AS SELECT … WHERE col = $1` (the shape the proxy emits) fell back to sequential scan even when a btree index on the column was present.

## Change

New file `src/operators/cross_type_operator_class.sql` registers the missing entries:

- **Cross-type compare functions**: `eql_v2.compare(eql_v2_encrypted, jsonb)` and the reverse direction. Each delegates to the same-type `compare` via the existing implicit `jsonb → eql_v2_encrypted` cast.
- **Cross-type hash function**: `eql_v2.hash_encrypted(jsonb)`, delegating to the same-type hash so equal values across the type pair land in the same hash bucket (hash-join correctness requirement).
- **`ALTER OPERATOR FAMILY` registrations**:
  - `encrypted_operator_family` (btree): all 10 cross-type strategy entries (5 strategies × 2 type orderings) + `FUNCTION 1` for both compare directions.
  - `encrypted_hash_operator_family` (hash): cross-type `=` in both directions + `FUNCTION 1` for the jsonb hash.

## Validation

On the 10K-row bench fixture:

| Path | Before | After |
| --- | --- | --- |
| `WHERE encrypted_int = '...'::jsonb` | Parallel Seq Scan, cost ~5029 | Index Scan + Index Cond, cost 9.18 |
| `PREPARE p (jsonb) AS … = $1` | Parallel Seq Scan | Index Scan + Index Cond, cost 9.18 |
| `WHERE encrypted_int > '...'::jsonb` | Index Scan + Filter (partial — only via ORDER BY traversal) | Index Scan + Index Cond |
| `WHERE encrypted_int BETWEEN '...'::jsonb AND '...'::jsonb` | already worked via implicit cast | Index Scan + Index Cond |

At 1M rows the same shape goes from ~18s to milliseconds — collapses the long-tail seq-scan regressions previously observed against the proxy parameter shape.

## Tests

In `bench_plan_tests.rs`:
- The two `#[ignore]`'d CIP-2831 tests (`eql_cast_text_equality_uses_btree_index`, `ore_equality_uses_btree_index`) are now un-ignored and pass. Renamed the first from `eql_cast_equality_uses_hash_index` since direct equality on the column correctly resolves to the btree — the planner picks the cheaper plan.
- New `ore_equality_with_bare_jsonb_uses_btree_index` covers the `WHERE col = '...'::jsonb` shape (no second cast).
- New `ore_range_with_bare_jsonb_uses_btree_index` covers `WHERE col > jsonb ORDER BY LIMIT`, asserting **Index Cond pushdown** rather than just Index Scan + Filter.

Full SQLx suite passes locally (33 test targets, 0 failures, 0 panics).

## Supabase build

The Supabase build excludes operator-class machinery wholesale via the `*operator_class.sql` filename glob in `tasks/build.sh`. The new file is named `cross_type_operator_class.sql` so it's correctly excluded:

- `release/cipherstash-encrypt.sql` — 9 cross-type mentions ✅
- `release/cipherstash-encrypt-supabase.sql` — 0 cross-type mentions ✅
- `release/cipherstash-encrypt-protect.sql` — 9 cross-type mentions ✅

Supabase parity for ordering is being addressed separately via the OPE-index work and is out of scope here.

## Test plan

- [x] `cargo check --tests` (default + `--features bench`)
- [x] Full sqlx suite passes locally (33 targets)
- [x] EXPLAIN cost collapse confirmed against the 10K-row bench fixture
- [x] Build variants excluded/included as expected
- [x] CI run on this branch confirms the test suite still passes across PG14-17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-type support added so encrypted-column indexes can be used for comparisons between encrypted columns and JSON values (btree and hash).

* **Tests**
  * Benchmarks updated to assert index usage for encrypted equality and range queries involving JSON operands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->