### PR TITLE
test: mark create_encrypted_json overloads IMMUTABLE so function-call operands fold

### DIFF
--- a/tests/sqlx/migrations/004_install_test_helpers.sql
+++ b/tests/sqlx/migrations/004_install_test_helpers.sql
@@ -271,6 +271,7 @@ $$ LANGUAGE plpgsql;
 DROP FUNCTION IF EXISTS create_encrypted_json(integer);
 CREATE FUNCTION create_encrypted_json(id integer)
   RETURNS eql_v2_encrypted
+  IMMUTABLE
 AS $$
   DECLARE
     s text;
@@ -335,6 +336,7 @@ $$ LANGUAGE plpgsql;
 DROP FUNCTION IF EXISTS create_encrypted_json(integer, VARIADIC indexes text[]);
 CREATE FUNCTION create_encrypted_json(id integer, VARIADIC indexes text[])
   RETURNS eql_v2_encrypted
+  IMMUTABLE
 AS $$
   DECLARE
     j jsonb;
@@ -356,6 +358,7 @@ $$ LANGUAGE plpgsql;
 DROP FUNCTION IF EXISTS create_encrypted_json(VARIADIC indexes text[]);
 CREATE FUNCTION create_encrypted_json(VARIADIC indexes text[])
   RETURNS eql_v2_encrypted
+  IMMUTABLE
 AS $$
  DECLARE
     default_indexes text[];
@@ -408,6 +411,11 @@ $$ LANGUAGE plpgsql;
 
 
 DROP FUNCTION IF EXISTS create_encrypted_json();
+-- Intentionally NOT IMMUTABLE: this overload uses random() to pick an id,
+-- so each call must produce a fresh value. Marking it IMMUTABLE would let
+-- the planner fold it to a single value and reuse, defeating the point.
+-- The other create_encrypted_json overloads (with explicit id / indexes)
+-- are deterministic and IMMUTABLE.
 CREATE FUNCTION create_encrypted_json()
   RETURNS eql_v2_encrypted
 AS $$

--- a/tests/sqlx/tests/bench_data_tests.rs
+++ b/tests/sqlx/tests/bench_data_tests.rs
@@ -131,6 +131,22 @@ async fn bench_hmac_equality_uses_hash_index(pool: PgPool) -> Result<()> {
     Ok(())
 }
 
+/// Verify hash index is used when the operand is a function-call expression
+/// (rather than a literal jsonb that PG can constant-fold trivially).
+///
+/// Regression test for the volatility blind spot: if `create_encrypted_json`
+/// is VOLATILE, PostgreSQL won't fold the function call at plan time, the
+/// indexed-expression match against `bench_text_hmac_idx` fails, and the
+/// query falls back to a sequential scan. Marking the helper IMMUTABLE
+/// (in 004_install_test_helpers.sql) is what keeps this assertion green.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
+async fn bench_hmac_equality_via_function_call_uses_hash_index(pool: PgPool) -> Result<()> {
+    let sql = "SELECT * FROM bench WHERE eql_v2.hmac_256(encrypted_text) \
+               = eql_v2.hmac_256(create_encrypted_json(1))";
+    assert_uses_index(&pool, sql, "bench_text_hmac_idx").await?;
+    Ok(())
+}
+
 /// Verify btree index is used for ORDER BY with LIMIT on encrypted_int
 #[sqlx::test(fixtures(path = "../fixtures", scripts("bench_data", "bench_setup")))]
 async fn bench_ore_order_uses_btree_index(pool: PgPool) -> Result<()> {


### PR DESCRIPTION
Closes #184.

## Summary

Three of the four `create_encrypted_json` overloads in `tests/sqlx/migrations/004_install_test_helpers.sql` deterministically derive their output from input arguments, but were defaulting to `VOLATILE` (Postgres' default). Volatile function calls aren't constant-folded at plan time, so query expressions like

```sql
WHERE eql_v2.hmac_256(col) = eql_v2.hmac_256(create_encrypted_json(1))
```

fall back to a sequential scan — even though the equivalent literal-jsonb form picks the hmac functional index cleanly. The existing `bench_*_uses_*_index` tests pass only because they interpolate literal jsonb that PG can already fold.

## Change

Marked `IMMUTABLE`:
- `create_encrypted_json(integer)`
- `create_encrypted_json(integer, VARIADIC text[])`
- `create_encrypted_json(VARIADIC text[])`

Left `VOLATILE` (with a code comment explaining why):
- `create_encrypted_json()` — uses `random()` to pick an id, so each call must produce a fresh value. Folding would defeat the point of the no-arg variant.

New regression test `bench_hmac_equality_via_function_call_uses_hash_index` in `bench_data_tests.rs` asserts the function-call operand form engages `bench_text_hmac_idx`. Without this change it would fail (Seq Scan).

## Validation

| Check | Result |
| --- | --- |
| `pg_proc.provolatile` per overload | three `i` (immutable), one `v` (volatile) — as intended |
| `EXPLAIN` of `WHERE hmac_256(col) = hmac_256(create_encrypted_json(1))` | `Bitmap Index Scan on bench_text_hmac_idx`, cost ≈ 2391 ✅ (was Seq Scan, cost ≈ 10125) |
| `cargo test --test bench_data_tests` | 13/13 pass |
| `cargo fmt --check` | clean |

## Production impact

Zero. Proxy-bound parameters already fold correctly via prepared-statement parameter binding (verified locally). This is a pure test-methodology fix — closes a blind spot where the existing tests didn't exercise the function-call operand shape, so a future regression that broke proxy-style binding without also breaking literal-jsonb tests would have slipped through.

## Test plan

- [x] `cargo test --test bench_data_tests` passes (13/13)
- [x] `cargo fmt --check` clean
- [x] EXPLAIN confirms `bench_text_hmac_idx` is now used
- [ ] CI run on this branch confirms the same across PG14-17

## Related

- #186 — independent fix (cross-type opfamily registration); both addressed planner-visibility issues but at different layers.