### PR TITLE
fix(ci): mise flag order and remove hardcoded postgres port

### DIFF
--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -96,11 +96,11 @@ jobs:
 
       - name: Build and install EQL
         run: |
-          mise run --output prefix build --force
+          mise run --output prefix --force build
           cat release/cipherstash-encrypt.sql \
             | docker exec -i postgres-${POSTGRES_VERSION} \
                 psql -v ON_ERROR_STOP=1 \
-                  postgresql://cipherstash:password@localhost:5432/cipherstash -f-
+                  postgresql://cipherstash:password@localhost/cipherstash -f-
 
       - name: Run splinter
         run: |


### PR DESCRIPTION
Pass --force as a mise option before the build task name so it is interpreted correctly, and drop the explicit :5432 port from the psql connection string to use the port from the `mise` env.