### PR TITLE
docs(changelog): correct the 2.3.0 upgrade-notes summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ Each entry that ships in a published release links to the PR that introduced it.
 
 ### Upgrade notes
 
-See [`docs/upgrading/v2.3.md`](docs/upgrading/v2.3.md). Six numbered notes cover the indexing recipe shift (U-001), the hmac requirement for equality and hashing (U-002), the formalisation of Blake3 as ste_vec-internal (U-003 — now historical, see U-004), the breaking ste_vec element shape migration plus the new `eql_v2.hmac_256(col, '<selector>')` recipe (U-004), the Block-ORE-only contract for range operators (U-005), and the ste_vec ORE-CLLW field consolidation to a single `oc` field (U-006).
+See [`docs/upgrading/v2.3.md`](docs/upgrading/v2.3.md). Eight numbered notes cover the indexing recipe shift (U-001), the hmac requirement for equality and hashing (U-002), the formalisation of Blake3 as ste_vec-internal (U-003 — now historical, see U-004), the breaking ste_vec element shape migration (U-004), the Block-ORE-only contract for range operators (U-005), the ste_vec ORE-CLLW field consolidation to a single `oc` field (U-006), the typed `->` selector lookup returning `eql_v2.ste_vec_entry` (U-007), and the typed `stevec_query` containment needle (U-008).
 
 ## [2.2.1] — 2026-04
 


### PR DESCRIPTION
The `[2.3.0]` **Upgrade notes** paragraph said "Six numbered notes cover … (U-006)" — but v2.3 has **eight**. U-007 (typed `->` selector lookup) and U-008 (typed `stevec_query` containment) were added by #223 and are already referenced by the section's own `Added` entries, so the summary contradicted itself.

Also drops the mention of the removed fused `eql_v2.hmac_256(col, '<selector>')` recipe from the U-004 summary.

CHANGELOG-only; needed before tagging `eql-2.3.0` since this section is the release body.