### PR TITLE
ci(release): verify CHANGELOG entry on release + fix Release EQL badge

### DIFF
--- a/.github/workflows/release-eql.yml
+++ b/.github/workflows/release-eql.yml
@@ -24,6 +24,29 @@ permissions:
   contents: write
 
 jobs:
+  verify-changelog:
+    runs-on: ubuntu-latest
+    name: Verify CHANGELOG entry
+    # Only real (non-prerelease) eql-* releases. Pre-releases keep their
+    # entries under [Unreleased] until the final release is cut.
+    if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'eql') && github.event.release.prerelease == false }}
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: CHANGELOG.md has a section for this release
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG#eql-}"
+          escaped="${version//./\\.}"
+          if ! grep -qE "^## \[${escaped}\]" CHANGELOG.md; then
+            echo "::error file=CHANGELOG.md::No '## [${version}]' section in CHANGELOG.md at tag ${TAG}. The release was cut without promoting [Unreleased] -> [${version}] first. See the 'Cutting a release' section of CLAUDE.md."
+            exit 1
+          fi
+          echo "Found '## [${version}]' section in CHANGELOG.md."
+
   build-and-publish:
     runs-on: ubuntu-latest
     name: Build EQL

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Encrypt Query Language (EQL)
 
 [![Test EQL](https://github.com/cipherstash/encrypt-query-language/actions/workflows/test-eql.yml/badge.svg?branch=main)](https://github.com/cipherstash/encrypt-query-language/actions/workflows/test-eql.yml)
-[![Release EQL](https://github.com/cipherstash/encrypt-query-language/actions/workflows/release-eql.yml/badge.svg?branch=main)](https://github.com/cipherstash/encrypt-query-language/actions/workflows/release-eql.yml)
+[![Release EQL](https://github.com/cipherstash/encrypt-query-language/actions/workflows/release-eql.yml/badge.svg?event=release)](https://github.com/cipherstash/encrypt-query-language/actions/workflows/release-eql.yml)
 
 Encrypt Query Language (EQL) is a set of abstractions for transmitting, storing, and interacting with encrypted data and indexes in PostgreSQL.
 


### PR DESCRIPTION
## What

Two release-workflow hygiene fixes:

1. **`verify-changelog` job** in `release-eql.yml` — fails the Release EQL run when `CHANGELOG.md` at the tagged commit has no `## [<version>]` section.
2. **README badge fix** — the Release EQL badge tracked `?branch=main`; switched to `?event=release`.

## Why — the consistency check

`eql-2.3.1` was published without first promoting `CHANGELOG.md` `[Unreleased]` → `[2.3.1]` (the "Cutting a release" step in `CLAUDE.md`). Nothing flagged it. This job is a detective control: on every non-prerelease `eql-*` release it checks out the tagged commit and greps for `^## \[<version>\]`. If it's missing, the release run goes red with an actionable error.

- **Independent job** — it does not gate `build-and-publish` / `publish-docs`. The release is already published by the time the workflow runs, so blocking artifacts would only make things worse; instead the workflow goes red so the omission is visible and gets followed up.
- **Skips pre-releases** (`github.event.release.prerelease == false`) — `eql-2.3.0-pre.N` etc. keep their entries under `[Unreleased]` until the final cut, so they have no version section by design.

This is the detective option discussed; a fully preventive setup (release-please-style PR-driven releases + a tag ruleset) is a larger change and out of scope here.

## Why — the badge

The badge URL had `?branch=main`, but the Release EQL workflow effectively never runs *on* `main` — it runs on `release` tag events (`head_branch` = the tag, e.g. `eql-2.3.1`). Only two runs in history were on `main`, the most recent a **cancelled** `workflow_dispatch` from 2025-11-26 — which GitHub renders as a red "failing" badge. Every actual release (2.3.0, 2.3.1, all pre-releases) succeeded. `?event=release` makes the badge reflect the latest release run (currently `eql-2.3.1` — passing).

## Note

This PR touches `.github/workflows/release-eql.yml`, so the workflow's `pull_request` trigger will run it here. `verify-changelog` is gated on `github.event_name == 'release'`, so it is skipped on this PR run — that's expected.