### PR TITLE
feat(v3/sem): pin ORE comparators IMMUTABLE + regression test

### DIFF
--- a/src/v3/sem/ore_block_u64_8_256/functions.sql
+++ b/src/v3/sem/ore_block_u64_8_256/functions.sql
@@ -89,8 +89,16 @@ $$ LANGUAGE plpgsql;
 --! @param b eql_v3.ore_block_u64_8_256_term Second ORE term
 --! @return integer -1 if a < b, 0 if a = b, 1 if a > b
 --! @throws Exception if ciphertexts are different lengths
+--! @note Marked `IMMUTABLE` (the three `compare_ore_block_u64_8_256_term(s)`
+--!   overloads all are). This deliberately diverges from the v2 originals,
+--!   which carry no volatility marker and so default to `VOLATILE`. The
+--!   comparison is deterministic — its only crypto call, pgcrypto `encrypt()`,
+--!   is itself `IMMUTABLE STRICT PARALLEL SAFE` — so `IMMUTABLE` lets the
+--!   planner fold/cache these in ordering and index contexts. NOT `STRICT`:
+--!   the NULL-handling branches below are load-bearing for the array overload.
 CREATE FUNCTION eql_v3.compare_ore_block_u64_8_256_term(a eql_v3.ore_block_u64_8_256_term, b eql_v3.ore_block_u64_8_256_term)
   RETURNS integer
+  IMMUTABLE
   SET search_path = pg_catalog, extensions, public
 AS $$
   DECLARE
@@ -169,6 +177,7 @@ $$ LANGUAGE plpgsql;
 --! @return integer -1/0/1, or NULL if either array is NULL
 CREATE FUNCTION eql_v3.compare_ore_block_u64_8_256_terms(a eql_v3.ore_block_u64_8_256_term[], b eql_v3.ore_block_u64_8_256_term[])
 RETURNS integer
+  IMMUTABLE
   SET search_path = pg_catalog, extensions, public
 AS $$
   DECLARE
@@ -208,6 +217,7 @@ $$ LANGUAGE plpgsql;
 --! @return integer -1/0/1
 CREATE FUNCTION eql_v3.compare_ore_block_u64_8_256_terms(a eql_v3.ore_block_u64_8_256, b eql_v3.ore_block_u64_8_256)
 RETURNS integer
+  IMMUTABLE
   SET search_path = pg_catalog, extensions, public
 AS $$
   BEGIN

--- a/tests/sqlx/src/fixtures/cipherstash.rs
+++ b/tests/sqlx/src/fixtures/cipherstash.rs
@@ -52,6 +52,11 @@ async fn build_cipher() -> Result<Arc<ScopedCipher<AutoStrategy>>> {
     Ok(Arc::new(cipher))
 }
 
+/// The single encrypted-payload column name. Single-sourced here so the
+/// `ColumnConfig` built for encryption and the `INSERT` target column in the
+/// driver cannot drift apart.
+pub const PAYLOAD_COLUMN: &str = "payload";
+
 /// Build a `ColumnConfig` from the fixture spec's index list + cast.
 ///
 /// `IndexKind` is a typed enum — every value is a real EQL index by
@@ -59,11 +64,6 @@ async fn build_cipher() -> Result<Arc<ScopedCipher<AutoStrategy>>> {
 /// fail on an unknown index name. Extending fixture coverage to a new
 /// index is one variant on `IndexKind` plus one arm here, both compile-
 /// time checked.
-/// The single encrypted-payload column name. Single-sourced here so the
-/// `ColumnConfig` built for encryption and the `INSERT` target column in the
-/// driver cannot drift apart.
-pub const PAYLOAD_COLUMN: &str = "payload";
-
 pub fn column_config_for(spec_indexes: &[IndexKind], cast: Cast) -> Result<ColumnConfig> {
     let column_type = cast_to_column_type(cast)?;
     let mut config = ColumnConfig::build(PAYLOAD_COLUMN).casts_as(column_type);

--- a/tests/sqlx/tests/encrypted_domain/family/sem.rs
+++ b/tests/sqlx/tests/encrypted_domain/family/sem.rs
@@ -394,20 +394,29 @@ async fn jsonb_array_to_ore_block_input_shapes(pool: PgPool) -> Result<()> {
     Ok(())
 }
 
-/// T8 — Volatility pin: all three `compare_ore_block_u64_8_256_term(s)` overloads
-/// (term×term, term[]×term[], composite×composite) must be `IMMUTABLE`
-/// (`provolatile = 'i'`). This deliberately diverges from the `eql_v2`
-/// originals, which carry no marker and default to `VOLATILE`. The comparison
-/// is deterministic — pgcrypto `encrypt()` is itself `IMMUTABLE` — and the
-/// marker is what lets the planner fold/cache these in ordering/index contexts,
-/// so a silent regression to `VOLATILE` (e.g. dropping the keyword on a future
-/// edit) must fail CI.
+/// T8 — Catalog pin for all three `compare_ore_block_u64_8_256_term(s)` overloads
+/// (term×term, term[]×term[], composite×composite). Two load-bearing catalog
+/// properties are pinned at the same layer:
+///
+///   - `IMMUTABLE` (`provolatile = 'i'`). This deliberately diverges from the
+///     `eql_v2` originals, which carry no marker and default to `VOLATILE`. The
+///     comparison is deterministic — pgcrypto `encrypt()` is itself `IMMUTABLE`
+///     — and the marker is what lets the planner fold/cache these in
+///     ordering/index contexts, so a silent regression to `VOLATILE` (e.g.
+///     dropping the keyword on a future edit) must fail CI.
+///   - NOT `STRICT` (`proisstrict = false`). The NULL-handling branches inside
+///     the comparators are load-bearing (T3 pins their behaviour for the term
+///     overload). A stray `STRICT` would let PostgreSQL skip the body on a NULL
+///     argument, silently bypassing those branches. T3 guards this behaviourally
+///     for the term overload; this pins it at the catalog layer for all three,
+///     including the array/composite overloads T3 does not directly assert.
 #[sqlx::test]
 async fn ore_comparators_are_immutable(pool: PgPool) -> Result<()> {
-    let rows: Vec<(String, String)> = sqlx::query_as(
+    let rows: Vec<(String, String, bool)> = sqlx::query_as(
         r#"
         SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args,
-               p.provolatile::text                         AS provolatile
+               p.provolatile::text                         AS provolatile,
+               p.proisstrict                               AS isstrict
         FROM pg_catalog.pg_proc p
         WHERE p.pronamespace = 'eql_v3'::regnamespace
           AND p.proname IN (
@@ -421,17 +430,21 @@ async fn ore_comparators_are_immutable(pool: PgPool) -> Result<()> {
     .await?;
 
     // Pin the count so an overload silently disappearing (or a fourth appearing)
-    // also fails, not just a volatility flip.
+    // also fails, not just a volatility/strictness flip.
     assert_eq!(
         rows.len(),
         3,
         "expected exactly 3 compare overloads, found: {rows:?}"
     );
 
-    for (args, provolatile) in &rows {
+    for (args, provolatile, isstrict) in &rows {
         assert_eq!(
             provolatile, "i",
             "compare_ore_block_u64_8_256_term(s)({args}) must be IMMUTABLE, got provolatile={provolatile}"
+        );
+        assert!(
+            !isstrict,
+            "compare_ore_block_u64_8_256_term(s)({args}) must NOT be STRICT (NULL branches are load-bearing)"
         );
     }
     Ok(())

--- a/tests/sqlx/tests/encrypted_domain/family/sem.rs
+++ b/tests/sqlx/tests/encrypted_domain/family/sem.rs
@@ -393,3 +393,46 @@ async fn jsonb_array_to_ore_block_input_shapes(pool: PgPool) -> Result<()> {
 
     Ok(())
 }
+
+/// T8 — Volatility pin: all three `compare_ore_block_u64_8_256_term(s)` overloads
+/// (term×term, term[]×term[], composite×composite) must be `IMMUTABLE`
+/// (`provolatile = 'i'`). This deliberately diverges from the `eql_v2`
+/// originals, which carry no marker and default to `VOLATILE`. The comparison
+/// is deterministic — pgcrypto `encrypt()` is itself `IMMUTABLE` — and the
+/// marker is what lets the planner fold/cache these in ordering/index contexts,
+/// so a silent regression to `VOLATILE` (e.g. dropping the keyword on a future
+/// edit) must fail CI.
+#[sqlx::test]
+async fn ore_comparators_are_immutable(pool: PgPool) -> Result<()> {
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        r#"
+        SELECT pg_catalog.pg_get_function_arguments(p.oid) AS args,
+               p.provolatile::text                         AS provolatile
+        FROM pg_catalog.pg_proc p
+        WHERE p.pronamespace = 'eql_v3'::regnamespace
+          AND p.proname IN (
+            'compare_ore_block_u64_8_256_term',
+            'compare_ore_block_u64_8_256_terms'
+          )
+        ORDER BY args
+        "#,
+    )
+    .fetch_all(&pool)
+    .await?;
+
+    // Pin the count so an overload silently disappearing (or a fourth appearing)
+    // also fails, not just a volatility flip.
+    assert_eq!(
+        rows.len(),
+        3,
+        "expected exactly 3 compare overloads, found: {rows:?}"
+    );
+
+    for (args, provolatile) in &rows {
+        assert_eq!(
+            provolatile, "i",
+            "compare_ore_block_u64_8_256_term(s)({args}) must be IMMUTABLE, got provolatile={provolatile}"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## What

Mark the three `eql_v3.compare_ore_block_u64_8_256_term(s)` overloads `IMMUTABLE` (term×term, term[]×term[], composite×composite). They previously had no volatility marker and defaulted to `VOLATILE`.

## Why

The comparison is deterministic — its only crypto call, pgcrypto `encrypt()`, is itself `IMMUTABLE STRICT PARALLEL SAFE` — so marking the comparators `IMMUTABLE` lets the planner fold/cache them in ordering and index contexts.

```diff
 CREATE FUNCTION eql_v3.compare_ore_block_u64_8_256_term(a …, b …)
   RETURNS integer
+  IMMUTABLE
   SET search_path = pg_catalog, extensions, public
```

**NOT `STRICT`:** the NULL-handling branches in the array overload are load-bearing — a `STRICT` marker would let PostgreSQL skip the body on a NULL argument.

## Test

`family::sem::ore_comparators_are_immutable` (T8) asserts exactly 3 overloads exist and all carry `provolatile = 'i'`, so a silent regression to `VOLATILE` fails CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Encrypted data comparison functions now explicitly declared as immutable for enhanced query optimization and performance.
  * Enhanced documentation clarifying deterministic comparison behavior and NULL-handling expectations.

* **Tests**
  * Added test coverage to validate immutability declarations and prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->