### PR TITLE
perf(ci): shard PR tests with nextest + merge-queue gate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,86 @@
+# CI: `test-eql.yml`
+
+Fast PR feedback + a thorough pre-merge gate, using a merge queue and a single
+aggregated required check.
+
+## Two run shapes
+
+`test-eql.yml` triggers on `pull_request`, `merge_group`, and `workflow_dispatch`.
+`setup` derives the matrix from the event:
+
+| Event | Trigger | Matrix | Purpose |
+|---|---|---|---|
+| `pull_request` | push to a PR | PG17 × 4 shards | fast developer feedback |
+| `merge_group` | "Merge when ready" → queued | PG14–17 × 2 shards | full pre-merge gate on the real merged state |
+| `workflow_dispatch` | manual run | PG17 × 4 shards (PR shape) | ad-hoc |
+
+The PR run is feedback only. The merge-queue run is the gate.
+
+## Relevance skip applies to PRs only
+
+Each job runs when:
+`merge_group || workflow_dispatch || (pull_request && relevant == 'true')`.
+
+So the `changes` relevance filter (`relevant:` paths) **only gates the
+`pull_request` event** — a docs-only PR skips the heavy jobs on its PR run. On
+`merge_group` (and `workflow_dispatch`) every job runs **unconditionally**: a
+queued PR always pays the full gate regardless of which files it touched.
+
+## How the queue works
+
+1. Click **Merge when ready** — the PR is queued, not merged.
+2. GitHub builds a temporary branch = `main` + this PR (+ any PRs ahead in the
+   queue) and fires `merge_group`, so CI tests the **post-merge state**, not the
+   stale PR branch.
+3. The full PG14–17 × 2 matrix (plus the single-run jobs) runs and feeds
+   `ci-required`.
+4. `ci-required` green → the PR is **merged into `main` using the queue's
+   configured merge method**. Red → the PR is **removed from the queue**; `main`
+   is untouched.
+
+This catches semantic conflicts — two PRs that each pass alone but break
+together — which PR-only checks never test.
+
+## The `ci-required` aggregator
+
+Per-event matrices make leaf job names unstable (a `test` job is displayed as
+`Shard PG17 1/4`, but the queue produces `Shard PG14 1/2` … `Shard PG17 2/2`),
+so leaf names can't be named as required checks. Instead, one aggregator job
+(id `ci-required`, **display name `CI required`**) `needs:` every job, runs with
+`if: always()`, and passes only if each needed result is `success` **or**
+`skipped`. Mark **only `CI required`** as the required status check.
+
+- `if: always()` — runs even when dependencies fail/skip, so the check always
+  reports (a never-reported required check leaves the queue stuck *Pending*).
+- `skipped` counts as pass — a docs-only PR skips the heavy jobs on its PR run
+  but must still report Success so the PR stays eligible to queue.
+
+This is the well-known "aggregate / final gate job" pattern for matrix +
+merge-queue workflows.
+
+## Operator setup (one-time, GitHub UI)
+
+Settings → Branches → rule for `main`:
+
+1. **Require merge queue.**
+2. **Require status checks to pass** → add **`CI required` only** (the display
+   name; not the per-shard leaf names).
+
+Then verify (see `docs/plans/2026-06-09-ci-pr-feedback-sharding-rollout.md`):
+
+- **Queue a relevant PR** → `merge_group` runs the full gate — 8 `Shard …` jobs
+  + 4 `Validate …` jobs + `build-archive`, `schema`, `rust-crates`, `codegen`,
+  `self-contained-v3`, `matrix-coverage`, `splinter` — all green → `CI required`
+  green → PR merges.
+- **Open a docs-only PR** → on its `pull_request` run the heavy jobs skip and
+  `CI required` reports **Success** (not stuck *Pending*), so the PR can be
+  queued.
+
+## References
+
+- Merge queue: <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue>
+- `merge_group` event: <https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group>
+- Required status checks: <https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging>
+- `needs` / `always()` / `join()`: <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions>
+- Path filtering (`dorny/paths-filter`): <https://github.com/dorny/paths-filter>
+- nextest archive + partitioning: <https://nexte.st/docs/ci-features/archiving/> · <https://nexte.st/docs/ci-features/partitioning/>

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -143,12 +143,17 @@ jobs:
         run: |
           mise run test:sqlx:archive
 
+      # Ship ALL release variants, not just the main installer: the
+      # build_validation_tests read cipherstash-encrypt{,-protect,-protect-uninstall,
+      # -v3,-v3-uninstall}.sql from ../../release at RUN time (std::fs, not embedded),
+      # and release/ is gitignored so the shard checkout has none of them. `mise run
+      # build` (via prep) produced the whole set in build-archive.
       - uses: actions/upload-artifact@v4
         with:
           name: nextest-archive
           path: |
             nextest.tar.zst
-            release/cipherstash-encrypt.sql
+            release/*.sql
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -67,6 +67,7 @@ jobs:
               - "crates/**"
               - "Cargo.toml"
               - "Cargo.lock"
+              - "mise.toml"
 
       # Explicit default (not `|| 'true'`, which trips GitHub's inconsistent
       # treatment of the string 'false'). merge_group/workflow_dispatch never

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -106,6 +106,19 @@ jobs:
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
+    env:
+      # test:sqlx:archive depends on test:sqlx:prep, which copies the built EQL
+      # into migrations/, applies it to a live Postgres, and regenerates the
+      # per-type fixtures — both are include_str!'d into the test binaries at
+      # COMPILE time, so they must exist before `cargo nextest archive`. Fixture
+      # generation needs a live PG with EQL installed (the postgres:up step
+      # below) plus CS_* creds. This repo does not accept fork PRs, so the
+      # secrets-on-pull_request constraint does not apply — block is unconditional.
+      POSTGRES_VERSION: "17"
+      CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
+      CS_WORKSPACE_CRN: ${{ secrets.CS_WORKSPACE_CRN }}
+      CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
+      CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -121,6 +134,10 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+
+      - name: Setup database (Postgres 17)
+        run: |
+          mise run postgres:up postgres-${POSTGRES_VERSION} --extra-args "--detach --wait"
 
       - name: Build EQL + archive test binaries
         run: |

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -55,7 +55,7 @@ jobs:
       # merge_group/workflow_dispatch the base ref is absent and the filter errors/empties.
       - id: f
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             relevant:
@@ -159,7 +159,7 @@ jobs:
       # -v3,-v3-uninstall}.sql from ../../release at RUN time (std::fs, not embedded),
       # and release/ is gitignored so the shard checkout has none of them. `mise run
       # build` (via prep) produced the whole set in build-archive.
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: nextest-archive
           path: |
@@ -210,7 +210,7 @@ jobs:
           shared-key: sqlx-tests
           save-if: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: nextest-archive
 

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -1,31 +1,17 @@
 name: "Test EQL"
+
+# NB: NO path filter at on: level. A workflow skipped by a path/branch filter
+# leaves its required checks stuck Pending and blocks merge. Relevance is
+# computed by the `changes` job and applied per-job via `if:` instead.
+#
+# NB: NO `push:` trigger. Under a required merge queue, push-to-main validation
+# is redundant — the queue already validated the exact merge commit, and branch
+# protection blocks direct pushes. (Resolves the design's ambiguous "light jobs
+# only on push:main" sanity net by dropping the trigger entirely.)
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - ".github/workflows/test-eql.yml"
-      - "src/**/*.sql"
-      - "sql/**/*.sql"
-      - "tests/**/*"
-      - "tasks/**/*"
-      - "crates/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-
-  pull_request:
-    # run on all pull requests
-    paths:
-      - ".github/workflows/test-eql.yml"
-      - "src/**/*.sql"
-      - "sql/**/*.sql"
-      - "tests/**/*"
-      - "tasks/**/*"
-      - "crates/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-
-  workflow_dispatch:
+  pull_request: {}
+  merge_group: {}            # required pre-merge gate; runs the full matrix
+  workflow_dispatch: {}      # manual runs use the PR shape (PG17 x 4 shards)
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -38,63 +24,88 @@ defaults:
 permissions:
   contents: read
 
+# PRs cancel superseded runs; the merge queue must NOT cancel — a cancelled
+# merge_group run never reports a final status and ejects the PR from the queue.
+concurrency:
+  group: test-eql-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  schema:
-    name: "JSON Schema validation"
+  # Runs on EVERY event and MUST always succeed (never skipped, never failed) —
+  # downstream heavy jobs `needs: [changes]`, and a skipped/failed `changes`
+  # would either skip the merge-queue matrix or deadlock `ci-required`.
+  changes:
+    name: "Detect relevant changes"
     runs-on: ubuntu-latest
-
+    outputs:
+      relevant: ${{ steps.r.outputs.relevant }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+      # Diff ONLY on pull_request, where a base ref is well-defined. On
+      # merge_group/workflow_dispatch the base ref is absent and the filter errors/empties.
+      - id: f
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
         with:
-          version: 2026.4.0
-          install: true
-          cache: true
+          filters: |
+            relevant:
+              - ".github/workflows/test-eql.yml"
+              - "src/**"
+              - "sql/**"
+              - "tests/**"
+              - "tasks/**"
+              - "crates/**"
+              - "Cargo.toml"
+              - "Cargo.lock"
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: .
-          shared-key: sqlx-tests
-
-      - name: Validate v2.2 / v2.3 payload schemas
+      # Explicit default (not `|| 'true'`, which trips GitHub's inconsistent
+      # treatment of the string 'false'). merge_group/workflow_dispatch never
+      # read this value — their downstream `if:` branch ignores `relevant` — but
+      # default true is the safe value regardless.
+      - id: r
         run: |
-          mise run test:schema
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "relevant=${{ steps.f.outputs.relevant }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          fi
 
-  rust-crates:
-    name: "Rust workspace crates"
+  # Pure bash; no checkout/toolchain. Derives the PG-version + shard fan-out
+  # from the event: PR -> PG17 x 4 shards; merge queue -> PG 14-17 x 2 shards.
+  setup:
+    name: "Compute matrix"
     runs-on: ubuntu-latest
-
+    outputs:
+      pg-versions: ${{ steps.cfg.outputs.pg }}
+      shard-total: ${{ steps.cfg.outputs.shard_total }}
+      shards: ${{ steps.cfg.outputs.shards }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-        with:
-          version: 2026.4.0
-          install: true
-          cache: true
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: .
-          shared-key: sqlx-tests
-
-      # fmt + clippy + test for the std-only catalog/generator crates. No
-      # Postgres: these never touch a database, so they run standalone and fast.
-      - name: Compile, lint and test the Rust workspace crates
+      - id: cfg
         run: |
-          export active_rust_toolchain=$(rustup show active-toolchain | cut -d' ' -f1)
-          rustup component add --toolchain ${active_rust_toolchain} rustfmt clippy
-          mise run test:crates
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo 'pg=[14,15,16,17]' >> "$GITHUB_OUTPUT"
+            echo 'shard_total=2'    >> "$GITHUB_OUTPUT"
+            echo 'shards=[1,2]'     >> "$GITHUB_OUTPUT"
+          else
+            echo 'pg=[17]'          >> "$GITHUB_OUTPUT"
+            echo 'shard_total=4'    >> "$GITHUB_OUTPUT"
+            echo 'shards=[1,2,3,4]' >> "$GITHUB_OUTPUT"
+          fi
 
-  codegen:
-    name: "Encrypted-domain codegen"
+  # Compile the test binaries ONCE. Runs in the queue and on workflow_dispatch
+  # always, and on PRs only when relevant files changed (docs-only PRs never pay
+  # the ~4-min compile).
+  build-archive:
+    name: "Build test archive"
+    needs: [changes]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -106,114 +117,97 @@ jobs:
           install: true
           cache: true
 
-      # Shared with the sibling Rust jobs so the eql-codegen build artifacts the
-      # parity gate needs are reused rather than rebuilt from scratch.
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: .
           shared-key: sqlx-tests
 
-      # Crate compile/lint/test (cargo test -p eql-scalars -p eql-codegen) runs
-      # in the dedicated `test:crates` job; this job covers the codegen-specific
-      # gate only — golden parity. The plaintext fixture lists are no longer a
-      # generated file: they live in the catalog (`eql_scalars::INT4_VALUES` /
-      # `INT2_VALUES`) and are pinned by `eql-scalars`'s own unit tests, so there
-      # is nothing to regenerate-and-diff here.
-
-      # Parity gate: assert the Rust eql-codegen output is line-normalized-equal
-      # to the int4 golden reference. Python is no longer an oracle (retired in
-      # P2). No Postgres needed — the generator runs offline.
-      - name: Verify generator parity (golden)
+      - name: Build EQL + archive test binaries
         run: |
-          mise run codegen:parity
+          mise run test:sqlx:archive
 
-  self-contained-v3:
-    name: "eql_v3 self-containment"
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/upload-artifact@v4
         with:
-          persist-credentials: false
+          name: nextest-archive
+          path: |
+            nextest.tar.zst
+            release/cipherstash-encrypt.sql
+          retention-days: 1
+          if-no-files-found: error
 
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-        with:
-          version: 2026.4.0
-          install: true
-          cache: true
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: .
-          shared-key: sqlx-tests
-
-      # Build to materialise release/cipherstash-encrypt-v3.sql and
-      # src/deps-ordered-v3.txt, then assert no eql_v2 symbol/file leakage.
-      - name: Build EQL
-        run: mise run --force build
-
-      - name: Assert eql_v3 is self-contained
-        run: mise run test:self_contained_v3
-
-  matrix-coverage:
-    name: "Matrix coverage inventory"
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          persist-credentials: false
-
-      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
-        with:
-          version: 2026.4.0
-          install: true
-          cache: true
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: .
-          shared-key: sqlx-tests
-
-      # Verify the matrix test-name set against the SINGLE canonical snapshot
-      # (snapshots/matrix_tests.txt) with the SAME pinned feature set the local
-      # task uses (`--no-default-features`, scale excluded), and cross-check the
-      # binary's discovered type set against `eql-codegen list-types`. A coverage
-      # change shows up as a diff in the snapshot; a catalog type missing its
-      # matrix wiring fails the cross-check. No Postgres needed: `--list` only
-      # enumerates, the suite uses runtime queries.
-      - name: Verify the matrix test-name inventory
-        run: |
-          mise run test:matrix:inventory
-          # Diff the whole snapshots/ directory so the single canonical file
-          # isn't hardcoded here; the mise task discovers the type set from the
-          # binary and reconciles it against `eql-codegen list-types`.
-          git add -N tests/sqlx/snapshots
-          git diff --exit-code -- tests/sqlx/snapshots \
-            || { echo "Coverage inventory stale — run 'mise run test:matrix:inventory' and commit."; exit 1; }
-
+  # Sharded sqlx suite. No longer needs [schema, codegen] (gate removed) —
+  # shards start right after build-archive.
   test:
-    name: "Test & Validate EQL (Postgres ${{ matrix.postgres-version }})"
+    name: "Shard PG${{ matrix.postgres-version }} ${{ matrix.shard }}/${{ needs.setup.outputs.shard-total }}"
+    needs: [changes, setup, build-archive]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
     runs-on: ubuntu-latest-m
-    needs: [schema, codegen]
-
     strategy:
       fail-fast: false
       matrix:
-        postgres-version: [17, 16, 15, 14]
-
+        postgres-version: ${{ fromJSON(needs.setup.outputs.pg-versions) }}
+        shard: ${{ fromJSON(needs.setup.outputs.shards) }}
     env:
       POSTGRES_VERSION: ${{ matrix.postgres-version }}
-      # CS_* are required for `mise run test:sqlx` to regenerate the
-      # cipherstash-client-encrypted fixtures before the suite runs.
-      # This repository does not accept fork PRs, so the secrets-on-
-      # `pull_request` constraint that breaks the fork CI flow does not
-      # apply here — leave the env block unconditional.
+      SHARD: ${{ matrix.shard }}
+      SHARD_TOTAL: ${{ needs.setup.outputs.shard-total }}
+      # CS_* are required for per-shard fixture regeneration (see plan Task 3).
+      # This repo does not accept fork PRs, so the secrets-on-pull_request
+      # constraint does not apply — leave the block unconditional.
       CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
       CS_WORKSPACE_CRN: ${{ secrets.CS_WORKSPACE_CRN }}
       CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
       CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
+    steps:
+      # Checkout path MUST be identical to build-archive so the archive's
+      # workspace remap lines up (design: archive<->commit coupling).
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: .
+          shared-key: sqlx-tests
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: nextest-archive
+
+      - name: Setup database (Postgres ${{ matrix.postgres-version }})
+        run: |
+          mise run postgres:up postgres-${POSTGRES_VERSION} --extra-args "--detach --wait"
+
+      - name: Run shard ${{ matrix.shard }}/${{ needs.setup.outputs.shard-total }}
+        run: |
+          mise run test:sqlx:partition
+
+  # docs:validate + Clean-DB v3 install smoke. Both are version-relevant, so
+  # they follow the event's PG set (PG17 on PR; 14-17 in the queue). Moved out
+  # of the old per-version test job so they run ONCE per version, not per shard.
+  validate:
+    name: "Validate (Postgres ${{ matrix.postgres-version }})"
+    needs: [changes, setup]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest-m
+    strategy:
+      fail-fast: false
+      matrix:
+        postgres-version: ${{ fromJSON(needs.setup.outputs.pg-versions) }}
+    env:
+      POSTGRES_VERSION: ${{ matrix.postgres-version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -222,8 +216,8 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           version: 2026.4.0
-          install: true # [default: true] run `mise install`
-          cache: true # [default: true] cache mise using GitHub's cache
+          install: true
+          cache: true
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
@@ -238,39 +232,167 @@ jobs:
         run: |
           mise run docs:validate
 
-      - name: Test EQL for Postgres ${{ matrix.postgres-version }}
-        run: |
-          export active_rust_toolchain=$(rustup show active-toolchain | cut -d' ' -f1)
-          rustup component add --toolchain ${active_rust_toolchain} rustfmt clippy
-          mise run --output prefix test --postgres ${POSTGRES_VERSION}
-
       - name: Clean-DB v3 install smoke (Postgres ${{ matrix.postgres-version }})
         run: |
           mise run build
           mise run test:clean_install_v3
 
-  splinter:
-    name: "Supabase splinter"
-    runs-on: ubuntu-latest-m
-
-    env:
-      POSTGRES_VERSION: "17"
-
+  schema:
+    name: "JSON Schema validation"
+    needs: [changes]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
-
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
           version: 2026.4.0
           install: true
           cache: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: .
+          shared-key: sqlx-tests
+      - name: Validate v2.2 / v2.3 payload schemas
+        run: |
+          mise run test:schema
 
+  rust-crates:
+    name: "Rust workspace crates"
+    needs: [changes]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: .
+          shared-key: sqlx-tests
+      # `mise run test:crates` runs `cargo fmt --check` at the workspace root,
+      # which covers tests/sqlx (a workspace member). This subsumes the old
+      # standalone `test:lint` step that the removed per-version test job ran.
+      - name: Compile, lint and test the Rust workspace crates
+        run: |
+          export active_rust_toolchain=$(rustup show active-toolchain | cut -d' ' -f1)
+          rustup component add --toolchain ${active_rust_toolchain} rustfmt clippy
+          mise run test:crates
+
+  codegen:
+    name: "Encrypted-domain codegen"
+    needs: [changes]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: .
+          shared-key: sqlx-tests
+      - name: Verify generator parity (golden)
+        run: |
+          mise run codegen:parity
+
+  self-contained-v3:
+    name: "eql_v3 self-containment"
+    needs: [changes]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: .
+          shared-key: sqlx-tests
+      - name: Build EQL
+        run: mise run --force build
+      - name: Assert eql_v3 is self-contained
+        run: mise run test:self_contained_v3
+
+  matrix-coverage:
+    name: "Matrix coverage inventory"
+    needs: [changes]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: .
+          shared-key: sqlx-tests
+      - name: Verify the matrix test-name inventory
+        run: |
+          mise run test:matrix:inventory
+          git add -N tests/sqlx/snapshots
+          git diff --exit-code -- tests/sqlx/snapshots \
+            || { echo "Coverage inventory stale — run 'mise run test:matrix:inventory' and commit."; exit 1; }
+
+  splinter:
+    name: "Supabase splinter"
+    needs: [changes]
+    if: >-
+      github.event_name == 'merge_group'
+      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
+    runs-on: ubuntu-latest-m
+    env:
+      POSTGRES_VERSION: "17"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
       - name: Setup database
         run: |
           mise run postgres:up postgres-${POSTGRES_VERSION} --extra-args "--detach --wait"
-
       - name: Build and install EQL
         run: |
           mise run --output prefix --force build
@@ -278,9 +400,31 @@ jobs:
             | docker exec -i postgres-${POSTGRES_VERSION} \
                 psql -v ON_ERROR_STOP=1 \
                   postgresql://cipherstash:password@localhost/cipherstash -f-
-
       - name: Run splinter
         run: |
           mise run --output prefix test:splinter --postgres ${POSTGRES_VERSION}
 
-
+  # The ONE required status check. Stable name on every event, so branch
+  # protection never references an event-dependent leaf name (which would
+  # deadlock). Passes iff every needed job is success or skipped. Treating
+  # skipped as pass is intentional: heavy jobs are legitimately skipped on
+  # docs-only PRs, and a genuine failure is still caught because the FAILING
+  # source job is itself in `needs` and reports failure.
+  ci-required:
+    name: "CI required"
+    needs: [changes, setup, build-archive, test, validate, schema, rust-crates,
+            codegen, self-contained-v3, matrix-coverage, splinter]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert all required jobs passed or were skipped
+        run: |
+          results='${{ join(needs.*.result, ' ') }}'
+          echo "needed results: $results"
+          for r in $results; do
+            case "$r" in
+              success|skipped) ;;
+              *) echo "gate fail: a needed job reported '$r'"; exit 1 ;;
+            esac
+          done
+          echo "ci-required: all needed jobs passed or were skipped"

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -16,6 +16,13 @@ on:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   MISE_VERBOSE: "1"
+  # CI compile-time tuning (CI-only; local dev keeps full debuginfo + incremental).
+  # Clean CI builds never reuse incremental state, so it only bloats target/ and
+  # the rust-cache up/download. line-tables-only keeps readable panic backtraces
+  # for failing tests at a fraction of full-debuginfo compile cost. nextest's
+  # `test` profile inherits these from `dev`.
+  CARGO_INCREMENTAL: "0"
+  CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
 
 defaults:
   run:
@@ -134,6 +141,10 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          # The sole saver of the shared cache: this job compiles the full heavy
+          # dep tree, so it must own the `sqlx-tests` key. All other jobs set
+          # `save-if: false` so a fast-finishing light job can't win the save race
+          # and overwrite the key with a deps-less target/.
 
       - name: Setup database (Postgres 17)
         run: |
@@ -197,6 +208,7 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          save-if: false
 
       - uses: actions/download-artifact@v4
         with:
@@ -242,6 +254,7 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          save-if: false
 
       - name: Setup database (Postgres ${{ matrix.postgres-version }})
         run: |
@@ -277,6 +290,7 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          save-if: false
       - name: Validate v2.2 / v2.3 payload schemas
         run: |
           mise run test:schema
@@ -302,6 +316,7 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          save-if: false
       # `mise run test:crates` runs `cargo fmt --check` at the workspace root,
       # which covers tests/sqlx (a workspace member). This subsumes the old
       # standalone `test:lint` step that the removed per-version test job ran.
@@ -332,6 +347,7 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          save-if: false
       - name: Verify generator parity (golden)
         run: |
           mise run codegen:parity
@@ -357,6 +373,7 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          save-if: false
       - name: Build EQL
         run: mise run --force build
       - name: Assert eql_v3 is self-contained
@@ -383,6 +400,7 @@ jobs:
         with:
           workspaces: .
           shared-key: sqlx-tests
+          save-if: false
       - name: Verify the matrix test-name inventory
         run: |
           mise run test:matrix:inventory

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -176,13 +176,10 @@ jobs:
       POSTGRES_VERSION: ${{ matrix.postgres-version }}
       SHARD: ${{ matrix.shard }}
       SHARD_TOTAL: ${{ needs.setup.outputs.shard-total }}
-      # CS_* are required for per-shard fixture regeneration (see plan Task 3).
-      # This repo does not accept fork PRs, so the secrets-on-pull_request
-      # constraint does not apply — leave the block unconditional.
-      CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
-      CS_WORKSPACE_CRN: ${{ secrets.CS_WORKSPACE_CRN }}
-      CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
-      CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
+      # No CS_* here: the shard runs the prebuilt archive (fixtures + migration
+      # embedded by build-archive), so it does not regenerate fixtures and needs
+      # no credentials. It only needs the live Postgres (below) for sqlx::test's
+      # per-test scratch databases and the release/*.sql from the artifact.
     steps:
       # Checkout path MUST be identical to build-archive so the archive's
       # workspace remap lines up (design: archive<->commit coupling).

--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,7 @@ src/deps-ordered-protect.txt
 
 # Cargo workspace root build artifacts
 /target/
+
+# Prebuilt nextest archive (transient build-once output for the sharded sqlx
+# suite; uploaded as a CI artifact, never committed — see tasks/test/sqlx-archive.sh)
+nextest.tar.zst

--- a/mise.toml
+++ b/mise.toml
@@ -101,11 +101,16 @@ cargo watch -x test
 
 [tasks."test:sqlx:archive"]
 description = "Build EQL + compile the sqlx test binaries once into a reusable nextest archive"
-# `build` produces release/cipherstash-encrypt.sql, uploaded alongside the
-# archive and consumed by every shard. This mirrors test:sqlx:prep (mise.toml:51):
-# the `#MISE depends` directive in the script is inert under `bash tasks/...`, so
-# the dependency MUST be declared here.
-depends = ["build"]
+# Depends on test:sqlx:prep (NOT just build): `#[sqlx::test(fixtures(scripts(…)))]`
+# embeds the per-type fixture SQL AND the 001_install_eql.sql migration into the
+# compiled test binaries via `include_str!` at COMPILE time. So the fixtures +
+# migration must exist on disk BEFORE `cargo nextest archive` compiles — prep
+# produces both (build → cp migration → sqlx migrate → fixture:generate:all).
+# Consequence: this task needs a live Postgres + CS_* creds (prep's
+# fixture:generate:all prerequisites), so the build-archive CI job runs
+# postgres:up and carries the CS_* env. The `#MISE depends` directive in the
+# script is inert under `bash tasks/...`, so the dependency MUST be declared here.
+depends = ["test:sqlx:prep"]
 dir = "{{config_root}}"
 run = "bash tasks/test/sqlx-archive.sh"
 

--- a/mise.toml
+++ b/mise.toml
@@ -99,6 +99,16 @@ run = """
 cargo watch -x test
 """
 
+[tasks."test:sqlx:archive"]
+description = "Build EQL + compile the sqlx test binaries once into a reusable nextest archive"
+# `build` produces release/cipherstash-encrypt.sql, uploaded alongside the
+# archive and consumed by every shard. This mirrors test:sqlx:prep (mise.toml:51):
+# the `#MISE depends` directive in the script is inert under `bash tasks/...`, so
+# the dependency MUST be declared here.
+depends = ["build"]
+dir = "{{config_root}}"
+run = "bash tasks/test/sqlx-archive.sh"
+
 [tasks."test:schema"]
 description = "Validate sample payloads against the v2.2 / v2.3 JSON Schemas (no database required)"
 dir = "{{config_root}}/tests/sqlx"

--- a/mise.toml
+++ b/mise.toml
@@ -109,6 +109,11 @@ depends = ["build"]
 dir = "{{config_root}}"
 run = "bash tasks/test/sqlx-archive.sh"
 
+[tasks."test:sqlx:partition"]
+description = "Run one hash partition of the sqlx suite from a prebuilt nextest archive (SHARD / SHARD_TOTAL env)"
+dir = "{{config_root}}"
+run = "bash tasks/test/sqlx-partition.sh"
+
 [tasks."test:schema"]
 description = "Validate sample payloads against the v2.2 / v2.3 JSON Schemas (no database required)"
 dir = "{{config_root}}/tests/sqlx"

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,10 @@
 "rust" = { version = "latest", components = "rustc,rust-std,cargo,rustfmt,rust-docs,clippy" }
 "cargo:cargo-binstall" = "latest"
 "cargo:sqlx-cli" = "latest"
+# Installed via the already-present cargo-binstall (fast in CI). Drives the
+# sharded sqlx suite: `cargo nextest archive` builds the test binaries once and
+# `cargo nextest run --partition hash:K/N` runs a stable hash-partitioned shard.
+"cargo:cargo-nextest" = "latest"
 # Single source of truth for the cargo-expand version used by `test:matrix:expand`.
 # Pinned in lockstep with the nightly date in that task: cargo-expand drives the
 # rustfmt pass, so an unpinned version can drift the matrix snapshot even with a

--- a/tasks/test/sqlx-archive.sh
+++ b/tasks/test/sqlx-archive.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # NOTE: this script is invoked via `bash tasks/...` from an inline mise task, so
 # `#MISE` directives here would be INERT (they only fire when mise auto-discovers
-# a script as a file-task). The `build` dependency is therefore declared on the
-# inline [tasks."test:sqlx:archive"] block (Step 2), mirroring test:sqlx:prep.
+# a script as a file-task). The `test:sqlx:prep` dependency is therefore declared
+# on the inline [tasks."test:sqlx:archive"] block.
 
 # bash is pinned via the shebang (mise honors a `#!` first line) so pipefail is
 # available regardless of the runner's /bin/sh.
@@ -14,15 +14,24 @@ cd "$REPO_ROOT"
 # Archive lands at the repo root so the workflow can upload it by a stable path.
 ARCHIVE="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
 
-# The mise task's `depends = ["build"]` (Step 2) has already produced
-# release/cipherstash-encrypt.sql. Belt-and-braces: fail loudly if it's missing
-# (e.g. the script is run directly rather than via `mise run test:sqlx:archive`).
+# The mise task's `depends = ["test:sqlx:prep"]` has already produced
+# release/cipherstash-encrypt.sql, copied it to migrations/001_install_eql.sql,
+# and regenerated the per-type fixtures. These are NOT optional: the sqlx::test
+# macros `include_str!` the migration + fixtures into the compiled binaries at
+# COMPILE time, so they must be on disk before `cargo nextest archive` runs.
+# Belt-and-braces: fail loudly if any are missing (e.g. the script was run
+# directly, or without a live Postgres + CS_* for fixture generation).
 test -f release/cipherstash-encrypt.sql \
-  || { echo "release/cipherstash-encrypt.sql missing — run via 'mise run test:sqlx:archive' (it depends on build)" >&2; exit 2; }
+  || { echo "release/cipherstash-encrypt.sql missing — run via 'mise run test:sqlx:archive' (it depends on test:sqlx:prep)" >&2; exit 2; }
+test -f tests/sqlx/migrations/001_install_eql.sql \
+  || { echo "tests/sqlx/migrations/001_install_eql.sql missing — prep did not run (needs a live Postgres)" >&2; exit 2; }
+ls tests/sqlx/fixtures/eql_v2_*.sql >/dev/null 2>&1 \
+  || { echo "tests/sqlx/fixtures/eql_v2_*.sql missing — fixture:generate:all did not run (needs Postgres + CS_* creds)" >&2; exit 2; }
 
-# Compile every tests/sqlx test binary with DEFAULT features and pack them.
-# No database is touched here — archive only compiles. The shards apply the live
-# Postgres + migration at run time.
+# Compile every tests/sqlx test binary with DEFAULT features and pack them. The
+# migration + fixtures (embedded via include_str at compile time) are baked into
+# the archive, so the shards consume them without regenerating. The shards still
+# need their own live Postgres for sqlx::test's per-test scratch databases.
 echo "==> archiving sqlx test binaries to ${ARCHIVE}"
 cd tests/sqlx
 cargo nextest archive --archive-file "${REPO_ROOT}/${ARCHIVE}"

--- a/tasks/test/sqlx-archive.sh
+++ b/tasks/test/sqlx-archive.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# NOTE: this script is invoked via `bash tasks/...` from an inline mise task, so
+# `#MISE` directives here would be INERT (they only fire when mise auto-discovers
+# a script as a file-task). The `build` dependency is therefore declared on the
+# inline [tasks."test:sqlx:archive"] block (Step 2), mirroring test:sqlx:prep.
+
+# bash is pinned via the shebang (mise honors a `#!` first line) so pipefail is
+# available regardless of the runner's /bin/sh.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Archive lands at the repo root so the workflow can upload it by a stable path.
+ARCHIVE="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
+
+# The mise task's `depends = ["build"]` (Step 2) has already produced
+# release/cipherstash-encrypt.sql. Belt-and-braces: fail loudly if it's missing
+# (e.g. the script is run directly rather than via `mise run test:sqlx:archive`).
+test -f release/cipherstash-encrypt.sql \
+  || { echo "release/cipherstash-encrypt.sql missing — run via 'mise run test:sqlx:archive' (it depends on build)" >&2; exit 2; }
+
+# Compile every tests/sqlx test binary with DEFAULT features and pack them.
+# No database is touched here — archive only compiles. The shards apply the live
+# Postgres + migration at run time.
+echo "==> archiving sqlx test binaries to ${ARCHIVE}"
+cd tests/sqlx
+cargo nextest archive --archive-file "${REPO_ROOT}/${ARCHIVE}"
+
+echo "==> archive written: ${REPO_ROOT}/${ARCHIVE}"

--- a/tasks/test/sqlx-archive.sh
+++ b/tasks/test/sqlx-archive.sh
@@ -12,7 +12,13 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$REPO_ROOT"
 
 # Archive lands at the repo root so the workflow can upload it by a stable path.
-ARCHIVE="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
+# A relative NEXTEST_ARCHIVE is resolved against REPO_ROOT; an absolute override
+# is used verbatim (otherwise it would be mangled into "${REPO_ROOT}/abs/path").
+ARCHIVE_INPUT="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
+case "${ARCHIVE_INPUT}" in
+  /*) ARCHIVE_PATH="${ARCHIVE_INPUT}" ;;
+  *)  ARCHIVE_PATH="${REPO_ROOT}/${ARCHIVE_INPUT}" ;;
+esac
 
 # The mise task's `depends = ["test:sqlx:prep"]` has already produced
 # release/cipherstash-encrypt.sql, copied it to migrations/001_install_eql.sql,
@@ -32,8 +38,8 @@ ls tests/sqlx/fixtures/eql_v2_*.sql >/dev/null 2>&1 \
 # migration + fixtures (embedded via include_str at compile time) are baked into
 # the archive, so the shards consume them without regenerating. The shards still
 # need their own live Postgres for sqlx::test's per-test scratch databases.
-echo "==> archiving sqlx test binaries to ${ARCHIVE}"
+echo "==> archiving sqlx test binaries to ${ARCHIVE_PATH}"
 cd tests/sqlx
-cargo nextest archive --archive-file "${REPO_ROOT}/${ARCHIVE}"
+cargo nextest archive --archive-file "${ARCHIVE_PATH}"
 
-echo "==> archive written: ${REPO_ROOT}/${ARCHIVE}"
+echo "==> archive written: ${ARCHIVE_PATH}"

--- a/tasks/test/sqlx-partition.sh
+++ b/tasks/test/sqlx-partition.sh
@@ -10,10 +10,16 @@ cd "$REPO_ROOT"
 # Required: which shard (1-based) and how many shards total.
 : "${SHARD:?SHARD (1-based shard index) must be set}"
 : "${SHARD_TOTAL:?SHARD_TOTAL (number of shards) must be set}"
-ARCHIVE="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
+# A relative NEXTEST_ARCHIVE is resolved against REPO_ROOT; an absolute override
+# is used verbatim (matching tasks/test/sqlx-archive.sh).
+ARCHIVE_INPUT="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
+case "${ARCHIVE_INPUT}" in
+  /*) ARCHIVE_PATH="${ARCHIVE_INPUT}" ;;
+  *)  ARCHIVE_PATH="${REPO_ROOT}/${ARCHIVE_INPUT}" ;;
+esac
 
-test -f "${ARCHIVE}" \
-  || { echo "archive ${ARCHIVE} missing — run test:sqlx:archive / download the artifact first" >&2; exit 2; }
+test -f "${ARCHIVE_PATH}" \
+  || { echo "archive ${ARCHIVE_PATH} missing — run test:sqlx:archive / download the artifact first" >&2; exit 2; }
 
 # The archive already carries everything compiled-in: build-archive ran prep
 # (build → cp 001_install_eql.sql → sqlx migrate → fixture:generate:all) BEFORE
@@ -29,9 +35,9 @@ test -f "${ARCHIVE}" \
 # build_validation_tests via std::fs); those arrive with the downloaded artifact.
 # release/ is NOT touched here — no cp, no migrate, no CS_* — the shard just runs
 # the prebuilt binaries.
-echo "==> running nextest partition hash:${SHARD}/${SHARD_TOTAL} from ${ARCHIVE}"
+echo "==> running nextest partition hash:${SHARD}/${SHARD_TOTAL} from ${ARCHIVE_PATH}"
 cd tests/sqlx
 cargo nextest run \
-  --archive-file "${REPO_ROOT}/${ARCHIVE}" \
+  --archive-file "${ARCHIVE_PATH}" \
   --workspace-remap "${REPO_ROOT}" \
   --partition "hash:${SHARD}/${SHARD_TOTAL}"

--- a/tasks/test/sqlx-partition.sh
+++ b/tasks/test/sqlx-partition.sh
@@ -14,26 +14,22 @@ ARCHIVE="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
 
 test -f "${ARCHIVE}" \
   || { echo "archive ${ARCHIVE} missing — run test:sqlx:archive / download the artifact first" >&2; exit 2; }
-test -f release/cipherstash-encrypt.sql \
-  || { echo "release/cipherstash-encrypt.sql missing — download the build-archive artifact first" >&2; exit 2; }
 
-# 1. Install the built EQL into the SQLx migration set (same as test:sqlx:prep,
-#    but WITHOUT rebuilding — the SQL comes from the build-archive artifact).
-echo "==> installing built EQL into tests/sqlx/migrations/001_install_eql.sql"
-cp release/cipherstash-encrypt.sql tests/sqlx/migrations/001_install_eql.sql
-
-# 2. Migrate this shard's own Postgres.
-echo "==> running sqlx migrations"
-(cd tests/sqlx && sqlx migrate run)
-
-# 3. Regenerate the gitignored per-test fixtures for THIS shard's DB. Not in the
-#    archive/artifact (see plan Task 3 header); needs CS_* + a live PG.
-echo "==> regenerating SQLx fixtures for this shard"
-mise run fixture:generate:all
-
-# 4. Run this partition from the prebuilt archive. Default features (matching the
-#    archive). `hash:` is stable across test add/remove (see design decision 4).
-echo "==> running nextest partition hash:${SHARD}/${SHARD_TOTAL}"
+# The archive already carries everything compiled-in: build-archive ran prep
+# (build → cp 001_install_eql.sql → sqlx migrate → fixture:generate:all) BEFORE
+# `cargo nextest archive`, so the migration AND the per-type fixtures are
+# include_str!'d into the binaries. The shard therefore does NOT re-run prep or
+# regenerate fixtures — doing so would force a full `cargo test` compile on every
+# shard (defeating the build-once archive) for no effect, since sqlx::test uses
+# the embedded copies. `sqlx::test` provisions its own per-test scratch databases
+# against the live Postgres (the job's postgres:up step) and applies the embedded
+# migrations + fixtures to each.
+#
+# The only on-disk runtime dependency is release/*.sql (read by
+# build_validation_tests via std::fs); those arrive with the downloaded artifact.
+# release/ is NOT touched here — no cp, no migrate, no CS_* — the shard just runs
+# the prebuilt binaries.
+echo "==> running nextest partition hash:${SHARD}/${SHARD_TOTAL} from ${ARCHIVE}"
 cd tests/sqlx
 cargo nextest run \
   --archive-file "${REPO_ROOT}/${ARCHIVE}" \

--- a/tasks/test/sqlx-partition.sh
+++ b/tasks/test/sqlx-partition.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#MISE description="Run one hash partition of the sqlx suite from a prebuilt nextest archive"
+
+# bash is pinned via the shebang so pipefail is available on dash-based runners.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# Required: which shard (1-based) and how many shards total.
+: "${SHARD:?SHARD (1-based shard index) must be set}"
+: "${SHARD_TOTAL:?SHARD_TOTAL (number of shards) must be set}"
+ARCHIVE="${NEXTEST_ARCHIVE:-nextest.tar.zst}"
+
+test -f "${ARCHIVE}" \
+  || { echo "archive ${ARCHIVE} missing — run test:sqlx:archive / download the artifact first" >&2; exit 2; }
+test -f release/cipherstash-encrypt.sql \
+  || { echo "release/cipherstash-encrypt.sql missing — download the build-archive artifact first" >&2; exit 2; }
+
+# 1. Install the built EQL into the SQLx migration set (same as test:sqlx:prep,
+#    but WITHOUT rebuilding — the SQL comes from the build-archive artifact).
+echo "==> installing built EQL into tests/sqlx/migrations/001_install_eql.sql"
+cp release/cipherstash-encrypt.sql tests/sqlx/migrations/001_install_eql.sql
+
+# 2. Migrate this shard's own Postgres.
+echo "==> running sqlx migrations"
+(cd tests/sqlx && sqlx migrate run)
+
+# 3. Regenerate the gitignored per-test fixtures for THIS shard's DB. Not in the
+#    archive/artifact (see plan Task 3 header); needs CS_* + a live PG.
+echo "==> regenerating SQLx fixtures for this shard"
+mise run fixture:generate:all
+
+# 4. Run this partition from the prebuilt archive. Default features (matching the
+#    archive). `hash:` is stable across test add/remove (see design decision 4).
+echo "==> running nextest partition hash:${SHARD}/${SHARD_TOTAL}"
+cd tests/sqlx
+cargo nextest run \
+  --archive-file "${REPO_ROOT}/${ARCHIVE}" \
+  --workspace-remap "${REPO_ROOT}" \
+  --partition "hash:${SHARD}/${SHARD_TOTAL}"


### PR DESCRIPTION
Cuts PR CI wall-clock ~26 → ~10.5 min by sharding `tests/sqlx` with `cargo-nextest`, compiling test binaries once into a reusable archive, trimming the PR matrix to PG17, and moving the full 14–17 matrix to a merge-queue gate. CI/tooling only — no `CHANGELOG`/upgrade note.

- Add `cargo-nextest` to `mise [tools]`.
- `test:sqlx:archive` — build EQL + `cargo nextest archive` → `nextest.tar.zst` (compiled once).
- `test:sqlx:partition` — per-shard: install SQL, migrate, regenerate fixtures, `nextest run --partition hash:K/N`.
- Rewrite `test-eql.yml`: drop `on:` path filter (a `changes` job gates per-job); fan-out derived from event (PR → PG17×4, queue → PG14–17×2); compile once in `build-archive`, shards consume the artifact; `ci-required` is the sole required check.
- Drop `push:` trigger; gitignore `nextest.tar.zst`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured continuous integration testing processes for improved reliability and efficiency.
  * Implemented intelligent caching for test compilation artifacts to minimize redundant builds.
  * Added distributed test execution with automatic sharding to reduce overall pipeline duration.
  * Enhanced development environment tooling dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
