### PR TITLE
test(codegen): capture generated sql references for scalar types

### DIFF
--- a/tests/codegen/reference/date/date_eq_functions.sql
+++ b/tests/codegen/reference/date/date_eq_functions.sql
@@ -1,0 +1,407 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/hmac_256/functions.sql
+
+--! @file encrypted_domain/date/date_eq_functions.sql
+--! @brief Functions for eql_v3.date_eq.
+
+--! @brief Index extractor for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.date_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.date_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.date_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.date_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.date_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector text
+--! @return eql_v3.date_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_eq, selector text)
+RETURNS eql_v3.date_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector integer
+--! @return eql_v3.date_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_eq, selector integer)
+RETURNS eql_v3.date_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param selector eql_v3.date_eq
+--! @return eql_v3.date_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date_eq)
+RETURNS eql_v3.date_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param selector eql_v3.date_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b eql_v3.date_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_eq, b eql_v3.date_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a eql_v3.date_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_eq.
+--! @param a jsonb
+--! @param b eql_v3.date_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_eq'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/date/date_eq_operators.sql
+++ b/tests/codegen/reference/date/date_eq_operators.sql
@@ -1,0 +1,234 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/date/date_eq_functions.sql
+
+--! @file encrypted_domain/date/date_eq_operators.sql
+--! @brief Operators for eql_v3.date_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = eql_v3.date_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_eq
+);

--- a/tests/codegen/reference/date/date_functions.sql
+++ b/tests/codegen/reference/date/date_functions.sql
@@ -1,0 +1,404 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+
+--! @file encrypted_domain/date/date_functions.sql
+--! @brief Functions for eql_v3.date.
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector text
+--! @return eql_v3.date
+CREATE FUNCTION eql_v3."->"(a eql_v3.date, selector text)
+RETURNS eql_v3.date IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector integer
+--! @return eql_v3.date
+CREATE FUNCTION eql_v3."->"(a eql_v3.date, selector integer)
+RETURNS eql_v3.date IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param selector eql_v3.date
+--! @return eql_v3.date
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date)
+RETURNS eql_v3.date IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param selector eql_v3.date
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b eql_v3.date
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date, b eql_v3.date)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a eql_v3.date
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date.
+--! @param a jsonb
+--! @param b eql_v3.date
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/date/date_operators.sql
+++ b/tests/codegen/reference/date/date_operators.sql
@@ -1,0 +1,228 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/date/date_functions.sql
+
+--! @file encrypted_domain/date/date_operators.sql
+--! @brief Operators for eql_v3.date.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date, RIGHTARG = eql_v3.date
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date
+);

--- a/tests/codegen/reference/date/date_ord_aggregates.sql
+++ b/tests/codegen/reference/date/date_ord_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/date/date_ord_functions.sql
+-- REQUIRE: src/v3/scalars/date/date_ord_operators.sql
+
+--! @file encrypted_domain/date/date_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.date_ord.
+
+--! @brief State function for min on eql_v3.date_ord.
+--! @param state eql_v3.date_ord
+--! @param value eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.date_ord, value eql_v3.date_ord)
+RETURNS eql_v3.date_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.date_ord.
+--! @param input eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.date_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.date_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.date_ord.
+--! @param state eql_v3.date_ord
+--! @param value eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.date_ord, value eql_v3.date_ord)
+RETURNS eql_v3.date_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.date_ord.
+--! @param input eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.date_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.date_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/date/date_ord_functions.sql
+++ b/tests/codegen/reference/date/date_ord_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/date/date_ord_functions.sql
+--! @brief Functions for eql_v3.date_ord.
+
+--! @brief Index extractor for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.date_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.date_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector text
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord, selector text)
+RETURNS eql_v3.date_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector integer
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord, selector integer)
+RETURNS eql_v3.date_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord
+--! @return eql_v3.date_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date_ord)
+RETURNS eql_v3.date_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b eql_v3.date_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord, b eql_v3.date_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a eql_v3.date_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord.
+--! @param a jsonb
+--! @param b eql_v3.date_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/date/date_ord_operators.sql
+++ b/tests/codegen/reference/date/date_ord_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/date/date_ord_functions.sql
+
+--! @file encrypted_domain/date/date_ord_operators.sql
+--! @brief Operators for eql_v3.date_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = eql_v3.date_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord
+);

--- a/tests/codegen/reference/date/date_ord_ore_aggregates.sql
+++ b/tests/codegen/reference/date/date_ord_ore_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/date/date_ord_ore_functions.sql
+-- REQUIRE: src/v3/scalars/date/date_ord_ore_operators.sql
+
+--! @file encrypted_domain/date/date_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.date_ord_ore.
+
+--! @brief State function for min on eql_v3.date_ord_ore.
+--! @param state eql_v3.date_ord_ore
+--! @param value eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.date_ord_ore, value eql_v3.date_ord_ore)
+RETURNS eql_v3.date_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.date_ord_ore.
+--! @param input eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.date_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.date_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.date_ord_ore.
+--! @param state eql_v3.date_ord_ore
+--! @param value eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.date_ord_ore, value eql_v3.date_ord_ore)
+RETURNS eql_v3.date_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.date_ord_ore.
+--! @param input eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.date_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.date_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/date/date_ord_ore_functions.sql
+++ b/tests/codegen/reference/date/date_ord_ore_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/date/date_ord_ore_functions.sql
+--! @brief Functions for eql_v3.date_ord_ore.
+
+--! @brief Index extractor for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.date_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.date_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.date_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.date_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.date_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector text
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord_ore, selector text)
+RETURNS eql_v3.date_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector integer
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.date_ord_ore, selector integer)
+RETURNS eql_v3.date_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord_ore
+--! @return eql_v3.date_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.date_ord_ore)
+RETURNS eql_v3.date_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.date_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.date_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.date_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.date_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.date_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.date_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.date_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.date_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.date_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.date_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.date_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.date_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b eql_v3.date_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord_ore, b eql_v3.date_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a eql_v3.date_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.date_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.date_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.date_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.date_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.date_ord_ore'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/date/date_ord_ore_operators.sql
+++ b/tests/codegen/reference/date/date_ord_ore_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/date/date_types.sql
+-- REQUIRE: src/v3/scalars/date/date_ord_ore_functions.sql
+
+--! @file encrypted_domain/date/date_ord_ore_operators.sql
+--! @brief Operators for eql_v3.date_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = eql_v3.date_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.date_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.date_ord_ore
+);

--- a/tests/codegen/reference/date/date_types.sql
+++ b/tests/codegen/reference/date/date_types.sql
@@ -1,0 +1,73 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+
+--! @file v3/scalars/date/date_types.sql
+--! @brief Encrypted-domain types for date.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.date.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.date_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.date_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.date_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'date_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.date_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;

--- a/tests/codegen/reference/int2/int2_eq_functions.sql
+++ b/tests/codegen/reference/int2/int2_eq_functions.sql
@@ -1,0 +1,407 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/hmac_256/functions.sql
+
+--! @file encrypted_domain/int2/int2_eq_functions.sql
+--! @brief Functions for eql_v3.int2_eq.
+
+--! @brief Index extractor for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.int2_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.int2_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int2_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.int2_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int2_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector text
+--! @return eql_v3.int2_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_eq, selector text)
+RETURNS eql_v3.int2_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector integer
+--! @return eql_v3.int2_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_eq, selector integer)
+RETURNS eql_v3.int2_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int2_eq
+--! @return eql_v3.int2_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2_eq)
+RETURNS eql_v3.int2_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int2_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b eql_v3.int2_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_eq, b eql_v3.int2_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a eql_v3.int2_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_eq.
+--! @param a jsonb
+--! @param b eql_v3.int2_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_eq'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int2/int2_eq_operators.sql
+++ b/tests/codegen/reference/int2/int2_eq_operators.sql
@@ -1,0 +1,234 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/int2/int2_eq_functions.sql
+
+--! @file encrypted_domain/int2/int2_eq_operators.sql
+--! @brief Operators for eql_v3.int2_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = eql_v3.int2_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_eq
+);

--- a/tests/codegen/reference/int2/int2_functions.sql
+++ b/tests/codegen/reference/int2/int2_functions.sql
@@ -1,0 +1,404 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+
+--! @file encrypted_domain/int2/int2_functions.sql
+--! @brief Functions for eql_v3.int2.
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector text
+--! @return eql_v3.int2
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2, selector text)
+RETURNS eql_v3.int2 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector integer
+--! @return eql_v3.int2
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2, selector integer)
+RETURNS eql_v3.int2 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param selector eql_v3.int2
+--! @return eql_v3.int2
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2)
+RETURNS eql_v3.int2 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param selector eql_v3.int2
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b eql_v3.int2
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2, b eql_v3.int2)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a eql_v3.int2
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2.
+--! @param a jsonb
+--! @param b eql_v3.int2
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int2/int2_operators.sql
+++ b/tests/codegen/reference/int2/int2_operators.sql
@@ -1,0 +1,228 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/int2/int2_functions.sql
+
+--! @file encrypted_domain/int2/int2_operators.sql
+--! @brief Operators for eql_v3.int2.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2, RIGHTARG = eql_v3.int2
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2
+);

--- a/tests/codegen/reference/int2/int2_ord_aggregates.sql
+++ b/tests/codegen/reference/int2/int2_ord_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/int2/int2_ord_functions.sql
+-- REQUIRE: src/v3/scalars/int2/int2_ord_operators.sql
+
+--! @file encrypted_domain/int2/int2_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.int2_ord.
+
+--! @brief State function for min on eql_v3.int2_ord.
+--! @param state eql_v3.int2_ord
+--! @param value eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int2_ord, value eql_v3.int2_ord)
+RETURNS eql_v3.int2_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int2_ord.
+--! @param input eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.int2_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int2_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int2_ord.
+--! @param state eql_v3.int2_ord
+--! @param value eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int2_ord, value eql_v3.int2_ord)
+RETURNS eql_v3.int2_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int2_ord.
+--! @param input eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.int2_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int2_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/int2/int2_ord_functions.sql
+++ b/tests/codegen/reference/int2/int2_ord_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/int2/int2_ord_functions.sql
+--! @brief Functions for eql_v3.int2_ord.
+
+--! @brief Index extractor for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int2_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int2_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector text
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord, selector text)
+RETURNS eql_v3.int2_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector integer
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord, selector integer)
+RETURNS eql_v3.int2_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord
+--! @return eql_v3.int2_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2_ord)
+RETURNS eql_v3.int2_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b eql_v3.int2_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord, b eql_v3.int2_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a eql_v3.int2_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int2/int2_ord_operators.sql
+++ b/tests/codegen/reference/int2/int2_ord_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/int2/int2_ord_functions.sql
+
+--! @file encrypted_domain/int2/int2_ord_operators.sql
+--! @brief Operators for eql_v3.int2_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = eql_v3.int2_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord
+);

--- a/tests/codegen/reference/int2/int2_ord_ore_aggregates.sql
+++ b/tests/codegen/reference/int2/int2_ord_ore_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/int2/int2_ord_ore_functions.sql
+-- REQUIRE: src/v3/scalars/int2/int2_ord_ore_operators.sql
+
+--! @file encrypted_domain/int2/int2_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.int2_ord_ore.
+
+--! @brief State function for min on eql_v3.int2_ord_ore.
+--! @param state eql_v3.int2_ord_ore
+--! @param value eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int2_ord_ore, value eql_v3.int2_ord_ore)
+RETURNS eql_v3.int2_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int2_ord_ore.
+--! @param input eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.int2_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int2_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int2_ord_ore.
+--! @param state eql_v3.int2_ord_ore
+--! @param value eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int2_ord_ore, value eql_v3.int2_ord_ore)
+RETURNS eql_v3.int2_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int2_ord_ore.
+--! @param input eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.int2_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int2_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/int2/int2_ord_ore_functions.sql
+++ b/tests/codegen/reference/int2/int2_ord_ore_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/int2/int2_ord_ore_functions.sql
+--! @brief Functions for eql_v3.int2_ord_ore.
+
+--! @brief Index extractor for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int2_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int2_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int2_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector text
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord_ore, selector text)
+RETURNS eql_v3.int2_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector integer
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int2_ord_ore, selector integer)
+RETURNS eql_v3.int2_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord_ore
+--! @return eql_v3.int2_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int2_ord_ore)
+RETURNS eql_v3.int2_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int2_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int2_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int2_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int2_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int2_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int2_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int2_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int2_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int2_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int2_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int2_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int2_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b eql_v3.int2_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord_ore, b eql_v3.int2_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a eql_v3.int2_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int2_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int2_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int2_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int2_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int2_ord_ore'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int2/int2_ord_ore_operators.sql
+++ b/tests/codegen/reference/int2/int2_ord_ore_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int2/int2_types.sql
+-- REQUIRE: src/v3/scalars/int2/int2_ord_ore_functions.sql
+
+--! @file encrypted_domain/int2/int2_ord_ore_operators.sql
+--! @brief Operators for eql_v3.int2_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = eql_v3.int2_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int2_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int2_ord_ore
+);

--- a/tests/codegen/reference/int2/int2_types.sql
+++ b/tests/codegen/reference/int2/int2_types.sql
@@ -1,0 +1,73 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+
+--! @file v3/scalars/int2/int2_types.sql
+--! @brief Encrypted-domain types for int2.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.int2.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2 AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int2_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int2_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int2_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int2_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int2_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;

--- a/tests/codegen/reference/int8/int8_eq_functions.sql
+++ b/tests/codegen/reference/int8/int8_eq_functions.sql
@@ -1,0 +1,407 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/hmac_256/functions.sql
+
+--! @file encrypted_domain/int8/int8_eq_functions.sql
+--! @brief Functions for eql_v3.int8_eq.
+
+--! @brief Index extractor for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.int8_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.int8_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int8_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.int8_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.int8_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector text
+--! @return eql_v3.int8_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_eq, selector text)
+RETURNS eql_v3.int8_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector integer
+--! @return eql_v3.int8_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_eq, selector integer)
+RETURNS eql_v3.int8_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int8_eq
+--! @return eql_v3.int8_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8_eq)
+RETURNS eql_v3.int8_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param selector eql_v3.int8_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b eql_v3.int8_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_eq, b eql_v3.int8_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a eql_v3.int8_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_eq.
+--! @param a jsonb
+--! @param b eql_v3.int8_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_eq'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int8/int8_eq_operators.sql
+++ b/tests/codegen/reference/int8/int8_eq_operators.sql
@@ -1,0 +1,234 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/int8/int8_eq_functions.sql
+
+--! @file encrypted_domain/int8/int8_eq_operators.sql
+--! @brief Operators for eql_v3.int8_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = eql_v3.int8_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_eq
+);

--- a/tests/codegen/reference/int8/int8_functions.sql
+++ b/tests/codegen/reference/int8/int8_functions.sql
@@ -1,0 +1,404 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+
+--! @file encrypted_domain/int8/int8_functions.sql
+--! @brief Functions for eql_v3.int8.
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector text
+--! @return eql_v3.int8
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8, selector text)
+RETURNS eql_v3.int8 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector integer
+--! @return eql_v3.int8
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8, selector integer)
+RETURNS eql_v3.int8 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param selector eql_v3.int8
+--! @return eql_v3.int8
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8)
+RETURNS eql_v3.int8 IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param selector eql_v3.int8
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b eql_v3.int8
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8, b eql_v3.int8)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a eql_v3.int8
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8.
+--! @param a jsonb
+--! @param b eql_v3.int8
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int8/int8_operators.sql
+++ b/tests/codegen/reference/int8/int8_operators.sql
@@ -1,0 +1,228 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/int8/int8_functions.sql
+
+--! @file encrypted_domain/int8/int8_operators.sql
+--! @brief Operators for eql_v3.int8.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8, RIGHTARG = eql_v3.int8
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8
+);

--- a/tests/codegen/reference/int8/int8_ord_aggregates.sql
+++ b/tests/codegen/reference/int8/int8_ord_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/int8/int8_ord_functions.sql
+-- REQUIRE: src/v3/scalars/int8/int8_ord_operators.sql
+
+--! @file encrypted_domain/int8/int8_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.int8_ord.
+
+--! @brief State function for min on eql_v3.int8_ord.
+--! @param state eql_v3.int8_ord
+--! @param value eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int8_ord, value eql_v3.int8_ord)
+RETURNS eql_v3.int8_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int8_ord.
+--! @param input eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.int8_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int8_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int8_ord.
+--! @param state eql_v3.int8_ord
+--! @param value eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int8_ord, value eql_v3.int8_ord)
+RETURNS eql_v3.int8_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int8_ord.
+--! @param input eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.int8_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int8_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/int8/int8_ord_functions.sql
+++ b/tests/codegen/reference/int8/int8_ord_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/int8/int8_ord_functions.sql
+--! @brief Functions for eql_v3.int8_ord.
+
+--! @brief Index extractor for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int8_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int8_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector text
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord, selector text)
+RETURNS eql_v3.int8_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector integer
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord, selector integer)
+RETURNS eql_v3.int8_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord
+--! @return eql_v3.int8_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8_ord)
+RETURNS eql_v3.int8_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b eql_v3.int8_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord, b eql_v3.int8_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a eql_v3.int8_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int8/int8_ord_operators.sql
+++ b/tests/codegen/reference/int8/int8_ord_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/int8/int8_ord_functions.sql
+
+--! @file encrypted_domain/int8/int8_ord_operators.sql
+--! @brief Operators for eql_v3.int8_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = eql_v3.int8_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord
+);

--- a/tests/codegen/reference/int8/int8_ord_ore_aggregates.sql
+++ b/tests/codegen/reference/int8/int8_ord_ore_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/int8/int8_ord_ore_functions.sql
+-- REQUIRE: src/v3/scalars/int8/int8_ord_ore_operators.sql
+
+--! @file encrypted_domain/int8/int8_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.int8_ord_ore.
+
+--! @brief State function for min on eql_v3.int8_ord_ore.
+--! @param state eql_v3.int8_ord_ore
+--! @param value eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.int8_ord_ore, value eql_v3.int8_ord_ore)
+RETURNS eql_v3.int8_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.int8_ord_ore.
+--! @param input eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.int8_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.int8_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.int8_ord_ore.
+--! @param state eql_v3.int8_ord_ore
+--! @param value eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.int8_ord_ore, value eql_v3.int8_ord_ore)
+RETURNS eql_v3.int8_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.int8_ord_ore.
+--! @param input eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.int8_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.int8_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/int8/int8_ord_ore_functions.sql
+++ b/tests/codegen/reference/int8/int8_ord_ore_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/int8/int8_ord_ore_functions.sql
+--! @brief Functions for eql_v3.int8_ord_ore.
+
+--! @brief Index extractor for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.int8_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.int8_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.int8_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector text
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord_ore, selector text)
+RETURNS eql_v3.int8_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector integer
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.int8_ord_ore, selector integer)
+RETURNS eql_v3.int8_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord_ore
+--! @return eql_v3.int8_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.int8_ord_ore)
+RETURNS eql_v3.int8_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.int8_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.int8_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.int8_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.int8_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.int8_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.int8_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.int8_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.int8_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.int8_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.int8_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.int8_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.int8_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b eql_v3.int8_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord_ore, b eql_v3.int8_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a eql_v3.int8_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.int8_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.int8_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.int8_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.int8_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.int8_ord_ore'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/int8/int8_ord_ore_operators.sql
+++ b/tests/codegen/reference/int8/int8_ord_ore_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/int8/int8_types.sql
+-- REQUIRE: src/v3/scalars/int8/int8_ord_ore_functions.sql
+
+--! @file encrypted_domain/int8/int8_ord_ore_operators.sql
+--! @brief Operators for eql_v3.int8_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = eql_v3.int8_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.int8_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.int8_ord_ore
+);

--- a/tests/codegen/reference/int8/int8_types.sql
+++ b/tests/codegen/reference/int8/int8_types.sql
@@ -1,0 +1,73 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+
+--! @file v3/scalars/int8/int8_types.sql
+--! @brief Encrypted-domain types for int8.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.int8.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8 AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int8_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int8_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.int8_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'int8_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.int8_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;

--- a/tests/codegen/reference/text/text_eq_functions.sql
+++ b/tests/codegen/reference/text/text_eq_functions.sql
@@ -1,0 +1,407 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/hmac_256/functions.sql
+
+--! @file encrypted_domain/text/text_eq_functions.sql
+--! @brief Functions for eql_v3.text_eq.
+
+--! @brief Index extractor for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.text_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.text_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.text_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.text_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.text_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector text
+--! @return eql_v3.text_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_eq, selector text)
+RETURNS eql_v3.text_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector integer
+--! @return eql_v3.text_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_eq, selector integer)
+RETURNS eql_v3.text_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param selector eql_v3.text_eq
+--! @return eql_v3.text_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_eq)
+RETURNS eql_v3.text_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param selector eql_v3.text_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b eql_v3.text_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_eq, b eql_v3.text_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a eql_v3.text_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_eq.
+--! @param a jsonb
+--! @param b eql_v3.text_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_eq'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/text/text_eq_operators.sql
+++ b/tests/codegen/reference/text/text_eq_operators.sql
@@ -1,0 +1,234 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/text/text_eq_functions.sql
+
+--! @file encrypted_domain/text/text_eq_operators.sql
+--! @brief Operators for eql_v3.text_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = eql_v3.text_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_eq
+);

--- a/tests/codegen/reference/text/text_functions.sql
+++ b/tests/codegen/reference/text/text_functions.sql
@@ -1,0 +1,404 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+
+--! @file encrypted_domain/text/text_functions.sql
+--! @brief Functions for eql_v3.text.
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector text
+--! @return eql_v3.text
+CREATE FUNCTION eql_v3."->"(a eql_v3.text, selector text)
+RETURNS eql_v3.text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector integer
+--! @return eql_v3.text
+CREATE FUNCTION eql_v3."->"(a eql_v3.text, selector integer)
+RETURNS eql_v3.text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param selector eql_v3.text
+--! @return eql_v3.text
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text)
+RETURNS eql_v3.text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param selector eql_v3.text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b eql_v3.text
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text, b eql_v3.text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a eql_v3.text
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text.
+--! @param a jsonb
+--! @param b eql_v3.text
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/text/text_match_functions.sql
+++ b/tests/codegen/reference/text/text_match_functions.sql
@@ -1,0 +1,407 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/bloom_filter/functions.sql
+
+--! @file encrypted_domain/text/text_match_functions.sql
+--! @brief Functions for eql_v3.text_match.
+
+--! @brief Index extractor for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @return eql_v3.bloom_filter
+CREATE FUNCTION eql_v3.match_term(a eql_v3.text_match)
+RETURNS eql_v3.bloom_filter
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.bloom_filter(a::jsonb) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_match, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_match)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) @> eql_v3.match_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_match, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) @> eql_v3.match_term(b::eql_v3.text_match) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a::eql_v3.text_match) @> eql_v3.match_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) <@ eql_v3.match_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_match, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a) <@ eql_v3.match_term(b::eql_v3.text_match) $$;
+
+--! @brief Operator wrapper for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_match)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.match_term(a::eql_v3.text_match) <@ eql_v3.match_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector text
+--! @return eql_v3.text_match
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_match, selector text)
+RETURNS eql_v3.text_match IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector integer
+--! @return eql_v3.text_match
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_match, selector integer)
+RETURNS eql_v3.text_match IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param selector eql_v3.text_match
+--! @return eql_v3.text_match
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_match)
+RETURNS eql_v3.text_match IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_match, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_match, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param selector eql_v3.text_match
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_match)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_match, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_match, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_match, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_match, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_match, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_match, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_match, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_match, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_match, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_match, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_match, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b eql_v3.text_match
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_match, b eql_v3.text_match)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a eql_v3.text_match
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_match, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_match.
+--! @param a jsonb
+--! @param b eql_v3.text_match
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_match)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_match'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/text/text_match_operators.sql
+++ b/tests/codegen/reference/text/text_match_operators.sql
@@ -1,0 +1,234 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/text/text_match_functions.sql
+
+--! @file encrypted_domain/text/text_match_operators.sql
+--! @brief Operators for eql_v3.text_match.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = <@, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb,
+  COMMUTATOR = <@, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = <@, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = @>, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb,
+  COMMUTATOR = @>, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match,
+  COMMUTATOR = @>, RESTRICT = contsel, JOIN = contjoinsel
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_match, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_match, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_match, RIGHTARG = eql_v3.text_match
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_match, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_match
+);

--- a/tests/codegen/reference/text/text_operators.sql
+++ b/tests/codegen/reference/text/text_operators.sql
@@ -1,0 +1,228 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/text/text_functions.sql
+
+--! @file encrypted_domain/text/text_operators.sql
+--! @brief Operators for eql_v3.text.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text, RIGHTARG = eql_v3.text
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text
+);

--- a/tests/codegen/reference/text/text_ord_aggregates.sql
+++ b/tests/codegen/reference/text/text_ord_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/text/text_ord_functions.sql
+-- REQUIRE: src/v3/scalars/text/text_ord_operators.sql
+
+--! @file encrypted_domain/text/text_ord_aggregates.sql
+--! @brief Aggregates for eql_v3.text_ord.
+
+--! @brief State function for min on eql_v3.text_ord.
+--! @param state eql_v3.text_ord
+--! @param value eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.text_ord, value eql_v3.text_ord)
+RETURNS eql_v3.text_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.text_ord.
+--! @param input eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE AGGREGATE eql_v3.min(eql_v3.text_ord) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.text_ord,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.text_ord.
+--! @param state eql_v3.text_ord
+--! @param value eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.text_ord, value eql_v3.text_ord)
+RETURNS eql_v3.text_ord
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.text_ord.
+--! @param input eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE AGGREGATE eql_v3.max(eql_v3.text_ord) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.text_ord,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/text/text_ord_functions.sql
+++ b/tests/codegen/reference/text/text_ord_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/text/text_ord_functions.sql
+--! @brief Functions for eql_v3.text_ord.
+
+--! @brief Index extractor for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.text_ord)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.text_ord) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_ord)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_ord)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector text
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord, selector text)
+RETURNS eql_v3.text_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector integer
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord, selector integer)
+RETURNS eql_v3.text_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord
+--! @return eql_v3.text_ord
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_ord)
+RETURNS eql_v3.text_ord IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_ord)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_ord, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_ord, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_ord, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_ord, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_ord, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b eql_v3.text_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord, b eql_v3.text_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a eql_v3.text_ord
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord.
+--! @param a jsonb
+--! @param b eql_v3.text_ord
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_ord)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/text/text_ord_operators.sql
+++ b/tests/codegen/reference/text/text_ord_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/text/text_ord_functions.sql
+
+--! @file encrypted_domain/text/text_ord_operators.sql
+--! @brief Operators for eql_v3.text_ord.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = eql_v3.text_ord
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord
+);

--- a/tests/codegen/reference/text/text_ord_ore_aggregates.sql
+++ b/tests/codegen/reference/text/text_ord_ore_aggregates.sql
@@ -1,0 +1,63 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/text/text_ord_ore_functions.sql
+-- REQUIRE: src/v3/scalars/text/text_ord_ore_operators.sql
+
+--! @file encrypted_domain/text/text_ord_ore_aggregates.sql
+--! @brief Aggregates for eql_v3.text_ord_ore.
+
+--! @brief State function for min on eql_v3.text_ord_ore.
+--! @param state eql_v3.text_ord_ore
+--! @param value eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3.min_sfunc(state eql_v3.text_ord_ore, value eql_v3.text_ord_ore)
+RETURNS eql_v3.text_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value < state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief min aggregate for eql_v3.text_ord_ore.
+--! @param input eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE AGGREGATE eql_v3.min(eql_v3.text_ord_ore) (
+  sfunc = eql_v3.min_sfunc,
+  stype = eql_v3.text_ord_ore,
+  combinefunc = eql_v3.min_sfunc,
+  parallel = safe
+);
+
+--! @brief State function for max on eql_v3.text_ord_ore.
+--! @param state eql_v3.text_ord_ore
+--! @param value eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3.max_sfunc(state eql_v3.text_ord_ore, value eql_v3.text_ord_ore)
+RETURNS eql_v3.text_ord_ore
+LANGUAGE plpgsql IMMUTABLE STRICT PARALLEL SAFE
+SET search_path = pg_catalog, extensions, public
+AS $$
+BEGIN
+  IF value > state THEN
+    RETURN value;
+  END IF;
+  RETURN state;
+END;
+$$;
+
+--! @brief max aggregate for eql_v3.text_ord_ore.
+--! @param input eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE AGGREGATE eql_v3.max(eql_v3.text_ord_ore) (
+  sfunc = eql_v3.max_sfunc,
+  stype = eql_v3.text_ord_ore,
+  combinefunc = eql_v3.max_sfunc,
+  parallel = safe
+);

--- a/tests/codegen/reference/text/text_ord_ore_functions.sql
+++ b/tests/codegen/reference/text/text_ord_ore_functions.sql
@@ -1,0 +1,396 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/functions.sql
+-- REQUIRE: src/v3/sem/ore_block_u64_8_256/operators.sql
+
+--! @file encrypted_domain/text/text_ord_ore_functions.sql
+--! @brief Functions for eql_v3.text_ord_ore.
+
+--! @brief Index extractor for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @return eql_v3.ore_block_u64_8_256
+CREATE FUNCTION eql_v3.ord_term(a eql_v3.text_ord_ore)
+RETURNS eql_v3.ore_block_u64_8_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ore_block_u64_8_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) = eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) = eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <> eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) <> eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) < eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) < eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) <= eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) <= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) > eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) > eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a) >= eql_v3.ord_term(b::eql_v3.text_ord_ore) $$;
+
+--! @brief Operator wrapper for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.ord_term(a::eql_v3.text_ord_ore) >= eql_v3.ord_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.text_ord_ore, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.text_ord_ore)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector text
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord_ore, selector text)
+RETURNS eql_v3.text_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector integer
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3."->"(a eql_v3.text_ord_ore, selector integer)
+RETURNS eql_v3.text_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord_ore
+--! @return eql_v3.text_ord_ore
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.text_ord_ore)
+RETURNS eql_v3.text_ord_ore IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord_ore, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.text_ord_ore, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param selector eql_v3.text_ord_ore
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.text_ord_ore)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.text_ord_ore, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.text_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.text_ord_ore, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.text_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.text_ord_ore, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.text_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.text_ord_ore, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord_ore, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord_ore, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.text_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.text_ord_ore, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b eql_v3.text_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord_ore, b eql_v3.text_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a eql_v3.text_ord_ore
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.text_ord_ore, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.text_ord_ore.
+--! @param a jsonb
+--! @param b eql_v3.text_ord_ore
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.text_ord_ore)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.text_ord_ore'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/text/text_ord_ore_operators.sql
+++ b/tests/codegen/reference/text/text_ord_ore_operators.sql
@@ -1,0 +1,246 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/text/text_types.sql
+-- REQUIRE: src/v3/scalars/text/text_ord_ore_functions.sql
+
+--! @file encrypted_domain/text/text_ord_ore_operators.sql
+--! @brief Operators for eql_v3.text_ord_ore.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >, NEGATOR = >=, RESTRICT = scalarltsel, JOIN = scalarltjoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = >=, NEGATOR = >, RESTRICT = scalarlesel, JOIN = scalarlejoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <, NEGATOR = <=, RESTRICT = scalargtsel, JOIN = scalargtjoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore,
+  COMMUTATOR = <=, NEGATOR = <, RESTRICT = scalargesel, JOIN = scalargejoinsel
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = eql_v3.text_ord_ore
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.text_ord_ore, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.text_ord_ore
+);

--- a/tests/codegen/reference/text/text_types.sql
+++ b/tests/codegen/reference/text/text_types.sql
@@ -1,0 +1,89 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+
+--! @file v3/scalars/text/text_types.sql
+--! @brief Encrypted-domain types for text.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.text.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_match.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_match' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_match AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'bf'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_ord_ore.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_ord_ore' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_ord_ore AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.text_ord.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'text_ord' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.text_ord AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'ob'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;

--- a/tests/codegen/reference/timestamptz/timestamptz_eq_functions.sql
+++ b/tests/codegen/reference/timestamptz/timestamptz_eq_functions.sql
@@ -1,0 +1,407 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/timestamptz/timestamptz_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+-- REQUIRE: src/v3/sem/hmac_256/functions.sql
+
+--! @file encrypted_domain/timestamptz/timestamptz_eq_functions.sql
+--! @brief Functions for eql_v3.timestamptz_eq.
+
+--! @brief Index extractor for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @return eql_v3.hmac_256
+CREATE FUNCTION eql_v3.eq_term(a eql_v3.timestamptz_eq)
+RETURNS eql_v3.hmac_256
+LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.hmac_256(a::jsonb) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) = eql_v3.eq_term(b::eql_v3.timestamptz_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamptz_eq) = eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a) <> eql_v3.eq_term(b::eql_v3.timestamptz_eq) $$;
+
+--! @brief Operator wrapper for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
+AS $$ SELECT eql_v3.eq_term(a::eql_v3.timestamptz_eq) <> eql_v3.eq_term(b) $$;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector text
+--! @return eql_v3.timestamptz_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_eq, selector text)
+RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector integer
+--! @return eql_v3.timestamptz_eq
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz_eq, selector integer)
+RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz_eq
+--! @return eql_v3.timestamptz_eq
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz_eq)
+RETURNS eql_v3.timestamptz_eq IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_eq, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz_eq, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz_eq
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz_eq)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz_eq, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz_eq, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz_eq, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz_eq, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz_eq, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b eql_v3.timestamptz_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_eq, b eql_v3.timestamptz_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a eql_v3.timestamptz_eq
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz_eq, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz_eq.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz_eq
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz_eq)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz_eq'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/timestamptz/timestamptz_eq_operators.sql
+++ b/tests/codegen/reference/timestamptz/timestamptz_eq_operators.sql
@@ -1,0 +1,234 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/timestamptz/timestamptz_types.sql
+-- REQUIRE: src/v3/scalars/timestamptz/timestamptz_eq_functions.sql
+
+--! @file encrypted_domain/timestamptz/timestamptz_eq_operators.sql
+--! @brief Operators for eql_v3.timestamptz_eq.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = =, NEGATOR = <>, RESTRICT = eqsel, JOIN = eqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq,
+  COMMUTATOR = <>, NEGATOR = =, RESTRICT = neqsel, JOIN = neqjoinsel
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = eql_v3.timestamptz_eq
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz_eq, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz_eq
+);

--- a/tests/codegen/reference/timestamptz/timestamptz_functions.sql
+++ b/tests/codegen/reference/timestamptz/timestamptz_functions.sql
@@ -1,0 +1,404 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/timestamptz/timestamptz_types.sql
+-- REQUIRE: src/v3/scalars/functions.sql
+
+--! @file encrypted_domain/timestamptz/timestamptz_functions.sql
+--! @brief Functions for eql_v3.timestamptz.
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.eq(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.neq(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lt(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.lte(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gt(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.gte(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '>=', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contains(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a eql_v3.timestamptz, b jsonb)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return boolean
+CREATE FUNCTION eql_v3.contained_by(a jsonb, b eql_v3.timestamptz)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '<@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector text
+--! @return eql_v3.timestamptz
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz, selector text)
+RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector integer
+--! @return eql_v3.timestamptz
+CREATE FUNCTION eql_v3."->"(a eql_v3.timestamptz, selector integer)
+RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz
+--! @return eql_v3.timestamptz
+CREATE FUNCTION eql_v3."->"(a jsonb, selector eql_v3.timestamptz)
+RETURNS eql_v3.timestamptz IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector text
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz, selector text)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param selector integer
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a eql_v3.timestamptz, selector integer)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param selector eql_v3.timestamptz
+--! @return text
+CREATE FUNCTION eql_v3."->>"(a jsonb, selector eql_v3.timestamptz)
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '->>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text
+--! @return boolean
+CREATE FUNCTION eql_v3."?"(a eql_v3.timestamptz, b text)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?|"(a eql_v3.timestamptz, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?|', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return boolean
+CREATE FUNCTION eql_v3."?&"(a eql_v3.timestamptz, b text[])
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '?&', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@?"(a eql_v3.timestamptz, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@?', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonpath
+--! @return boolean
+CREATE FUNCTION eql_v3."@@"(a eql_v3.timestamptz, b jsonpath)
+RETURNS boolean IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '@@', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#>"(a eql_v3.timestamptz, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return text
+CREATE FUNCTION eql_v3."#>>"(a eql_v3.timestamptz, b text[])
+RETURNS text IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#>>', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b text)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b integer
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b integer)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."-"(a eql_v3.timestamptz, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b text[]
+--! @return jsonb
+CREATE FUNCTION eql_v3."#-"(a eql_v3.timestamptz, b text[])
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '#-', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b eql_v3.timestamptz
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz, b eql_v3.timestamptz)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a eql_v3.timestamptz
+--! @param b jsonb
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a eql_v3.timestamptz, b jsonb)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;
+
+--! @brief Unsupported operator blocker for eql_v3.timestamptz.
+--! @param a jsonb
+--! @param b eql_v3.timestamptz
+--! @return jsonb
+CREATE FUNCTION eql_v3."||"(a jsonb, b eql_v3.timestamptz)
+RETURNS jsonb IMMUTABLE PARALLEL SAFE
+AS $$ BEGIN RAISE EXCEPTION 'operator % is not supported for %', '||', 'eql_v3.timestamptz'; END; $$
+LANGUAGE plpgsql;

--- a/tests/codegen/reference/timestamptz/timestamptz_operators.sql
+++ b/tests/codegen/reference/timestamptz/timestamptz_operators.sql
@@ -1,0 +1,228 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+-- REQUIRE: src/v3/scalars/timestamptz/timestamptz_types.sql
+-- REQUIRE: src/v3/scalars/timestamptz/timestamptz_functions.sql
+
+--! @file encrypted_domain/timestamptz/timestamptz_operators.sql
+--! @brief Operators for eql_v3.timestamptz.
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR = (
+  FUNCTION = eql_v3.eq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <> (
+  FUNCTION = eql_v3.neq,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR < (
+  FUNCTION = eql_v3.lt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <= (
+  FUNCTION = eql_v3.lte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR > (
+  FUNCTION = eql_v3.gt,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR >= (
+  FUNCTION = eql_v3.gte,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR @> (
+  FUNCTION = eql_v3.contains,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR <@ (
+  FUNCTION = eql_v3.contained_by,
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
+);
+
+CREATE OPERATOR -> (
+  FUNCTION = eql_v3."->",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
+);
+
+CREATE OPERATOR ->> (
+  FUNCTION = eql_v3."->>",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR ? (
+  FUNCTION = eql_v3."?",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR ?| (
+  FUNCTION = eql_v3."?|",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR ?& (
+  FUNCTION = eql_v3."?&",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR @? (
+  FUNCTION = eql_v3."@?",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR @@ (
+  FUNCTION = eql_v3."@@",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonpath
+);
+
+CREATE OPERATOR #> (
+  FUNCTION = eql_v3."#>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #>> (
+  FUNCTION = eql_v3."#>>",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = integer
+);
+
+CREATE OPERATOR - (
+  FUNCTION = eql_v3."-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR #- (
+  FUNCTION = eql_v3."#-",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = text[]
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = eql_v3.timestamptz
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = eql_v3.timestamptz, RIGHTARG = jsonb
+);
+
+CREATE OPERATOR || (
+  FUNCTION = eql_v3."||",
+  LEFTARG = jsonb, RIGHTARG = eql_v3.timestamptz
+);

--- a/tests/codegen/reference/timestamptz/timestamptz_types.sql
+++ b/tests/codegen/reference/timestamptz/timestamptz_types.sql
@@ -1,0 +1,41 @@
+-- REFERENCE: hand-maintained parity baseline for crates/eql-codegen - see ../README.md
+-- AUTOMATICALLY GENERATED FILE.
+-- REQUIRE: src/v3/schema.sql
+
+--! @file v3/scalars/timestamptz/timestamptz_types.sql
+--! @brief Encrypted-domain types for timestamptz.
+
+DO $$
+BEGIN
+  --! @brief Encrypted domain eql_v3.timestamptz.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamptz' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamptz AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+
+  --! @brief Encrypted domain eql_v3.timestamptz_eq.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type
+    WHERE typname = 'timestamptz_eq' AND typnamespace = 'eql_v3'::regnamespace
+  ) THEN
+    CREATE DOMAIN eql_v3.timestamptz_eq AS jsonb
+      CHECK (
+        jsonb_typeof(VALUE) = 'object'
+        AND VALUE ? 'v'
+        AND VALUE ? 'i'
+        AND VALUE ? 'c'
+        AND VALUE ? 'hm'
+        AND VALUE->>'v' = '2'
+      );
+  END IF;
+END
+$$;


### PR DESCRIPTION
## What

Captures the codegen **SQL references** for `int2`/`int8`/`date`/`text`/`timestamptz` alongside the existing `int4` set — 51 generated SQL files, byte-identical to `cargo run -p eql-codegen`. These exercise the eq-only and Bloom `text_match` render shapes that `int4` does not.

Pure generated SQL, no behaviour change. Base of a 2-PR split: carved off so the review changes in #270 aren't drowned by 13K lines of generated SQL.

## Stack

- **This PR** → base `eql_v3` — the references only.
- **#270** → base this branch — the Rust review changes plus the parity machinery that activates these references (dynamic dir discovery, `reference_dirs_match_catalog_tokens`, determinism test). Depends on these files and on `eql_codegen::repo_root`.

Until #270 lands the existing `int4` parity test is unaffected; the new references sit inert.

## Verification

- `cargo run -p eql-codegen` + per-file diff (strip `-- REFERENCE:` line): all 51 match byte-for-byte.
- `cargo test -p eql-codegen --test parity` (int4 gate): 2 passed.