### PR TITLE
fix(v3/sem): address CodeRabbit findings (hmac_256 inlining, ORE casing, fixture comment)

### DIFF
--- a/src/v3/sem/hmac_256/functions.sql
+++ b/src/v3/sem/hmac_256/functions.sql
@@ -33,10 +33,8 @@ $$;
 --! @return boolean True if 'hm' field is present and non-null
 CREATE FUNCTION eql_v3.has_hmac_256(val jsonb)
   RETURNS boolean
+  LANGUAGE sql
   IMMUTABLE STRICT PARALLEL SAFE
-  SET search_path = pg_catalog, extensions, public
 AS $$
-  BEGIN
-    RETURN val ->> 'hm' IS NOT NULL;
-  END;
-$$ LANGUAGE plpgsql;
+  SELECT (val ->> 'hm') IS NOT NULL
+$$;

--- a/src/v3/sem/ore_block_u64_8_256/functions.sql
+++ b/src/v3/sem/ore_block_u64_8_256/functions.sql
@@ -132,7 +132,7 @@ AS $$
     FOR block IN 0..7 LOOP
       IF
         substr(a.bytes, 1 + block, 1) != substr(b.bytes, 1 + block, 1)
-        OR substr(a.bytes, 9 + left_block_size * block, left_block_size) != substr(b.bytes, 9 + left_block_size * BLOCK, left_block_size)
+        OR substr(a.bytes, 9 + left_block_size * block, left_block_size) != substr(b.bytes, 9 + left_block_size * block, left_block_size)
       THEN
         IF eq THEN
           unequal_block := block;

--- a/tests/sqlx/fixtures/match_data.sql
+++ b/tests/sqlx/fixtures/match_data.sql
@@ -4,7 +4,7 @@
 -- Tests encrypted-to-encrypted matching using bloom filter indexes
 --
 -- Plaintext structure: {"hello": "world", "n": N}
--- where N is 10, 20, or 30 for records 1, 2, 3
+-- where N is 1, 2, or 3 for records 1, 2, 3
 
 -- Create table for LIKE operator tests
 DROP TABLE IF EXISTS encrypted CASCADE;


### PR DESCRIPTION
## Summary

Addresses three CodeRabbit review findings on the `eql_v3` SEM surface. All changes are confined to three files.

- **`hmac_256/functions.sql` — `has_hmac_256` made inlinable (real fix, low risk).** Was `LANGUAGE plpgsql` with a `SET search_path = ...` clause and a `BEGIN ... RETURN ... END;` body — both the plpgsql language and the `SET` clause defeat planner inlining, a documented footgun in this project (inlinable predicates must be `LANGUAGE sql`, single-statement `SELECT`, `IMMUTABLE`, no `SET` clause). Rewritten to mirror the sibling `eql_v3.hmac_256` extractor directly above it: `LANGUAGE sql`, `IMMUTABLE STRICT PARALLEL SAFE`, body `SELECT (val ->> 'hm') IS NOT NULL`. The body uses only the built-in `->>` operator, so dropping the pinned search_path is safe. No observable behaviour change — only planner inlining of this internal predicate.

- **`ore_block_u64_8_256/functions.sql` — `BLOCK` → `block` casing (cosmetic).** CodeRabbit flagged this as "critical", but it is **not** a runtime bug: PL/pgSQL is case-insensitive, so `BLOCK` already resolved to the loop variable `block` (`FOR block IN 0..7 LOOP`). The one uppercase `BLOCK` in the second `substr` of the comparator is lowercased for consistency with the rest of the loop. Zero behavioural impact.

- **`tests/sqlx/fixtures/match_data.sql` — header comment corrected (trivial doc).** The header said `N is 10, 20, or 30`, but the inserts call `create_encrypted_json(1/2/3)`. Confirmed the actual insert values and corrected the comment to `N is 1, 2, or 3`. Comment only; inserts unchanged.

## Validation

Ran `mise run clean && mise run build` (regenerates the scalar SQL via `cargo run -p eql-codegen`, then assembles the release SQL with tsort). **Build succeeded.** Confirmed in `release/cipherstash-encrypt-v3.sql`:
- `eql_v3.has_hmac_256` now renders as a `LANGUAGE sql` function with no `SET search_path`.
- No uppercase `left_block_size * BLOCK` remains in the ORE comparator.

Did not run the database-backed sqlx test suite (no PostgreSQL available, limited disk); the SEM files are hand-written (not codegen output) and the changes are textual/low-risk, so the build assembly is sufficient confirmation that the SQL parses and packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cryptographic block comparison logic to ensure correct equality checks.

* **Refactor**
  * Optimized HMAC validation function for improved performance and maintainability.

* **Tests**
  * Updated test fixture documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->