### PR TITLE
Matrix log verification — Stage 1: static catalog-coverage gate

### DIFF
--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -417,6 +417,8 @@ jobs:
           git add -N tests/sqlx/snapshots
           git diff --exit-code -- tests/sqlx/snapshots \
             || { echo "Coverage inventory stale — run the relevant inventory task and commit."; exit 1; }
+      - name: Verify catalog-surface coverage
+        run: mise run test:matrix:catalog-coverage
 
   splinter:
     name: "Supabase splinter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,7 @@ dependencies = [
  "eql-scalars",
  "minijinja",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/crates/eql-codegen/Cargo.toml
+++ b/crates/eql-codegen/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 eql-scalars = { path = "../eql-scalars" }
 minijinja = "2"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "2"
 
 [[bin]]

--- a/crates/eql-codegen/src/dump.rs
+++ b/crates/eql-codegen/src/dump.rs
@@ -81,7 +81,11 @@ mod tests {
         let segments: Vec<&str> = int4.domains.iter().map(|d| d.segment.as_str()).collect();
         assert_eq!(segments, ["storage", "eq", "ord_ore", "ord"]);
 
-        let storage = int4.domains.iter().find(|d| d.segment == "storage").unwrap();
+        let storage = int4
+            .domains
+            .iter()
+            .find(|d| d.segment == "storage")
+            .unwrap();
         assert!(storage.supported_ops.is_empty(), "storage has no operators");
 
         let eq = int4.domains.iter().find(|d| d.segment == "eq").unwrap();

--- a/crates/eql-codegen/src/dump.rs
+++ b/crates/eql-codegen/src/dump.rs
@@ -1,0 +1,106 @@
+//! `dump_catalog` — serialize the `eql_scalars::CATALOG` surface (each type's
+//! domains and their supported SQL operators) for downstream verification
+//! tooling. The reusable producer behind `eql-codegen -- dump-catalog`.
+//!
+//! Stage 1 consumes the `(type, domain)` shape; later stages consume the
+//! per-domain `supported_ops`. Blocked-operator tagging is added in Stage 4.
+
+use eql_scalars::{Term, CATALOG};
+use serde::Serialize;
+
+/// The catalog surface: every scalar type and its domains.
+#[derive(Serialize)]
+pub struct CatalogDump {
+    pub types: Vec<TypeEntry>,
+}
+
+#[derive(Serialize)]
+pub struct TypeEntry {
+    /// Catalog token, e.g. `int4`.
+    pub token: &'static str,
+    /// True when the type has no `_ord` domain (storage + `_eq` only).
+    pub is_eq_only: bool,
+    pub domains: Vec<DomainEntry>,
+}
+
+#[derive(Serialize)]
+pub struct DomainEntry {
+    /// Test-name segment: the base domain (`suffix == ""`) is `storage`;
+    /// otherwise the suffix without its leading underscore (`_eq` → `eq`,
+    /// `_ord_ore` → `ord_ore`).
+    pub segment: String,
+    /// Raw catalog suffix (`""`, `_eq`, `_ord`, `_ord_ore`, `_match`).
+    pub suffix: &'static str,
+    /// SQL operators the domain's terms support, in catalog order. Empty for
+    /// the storage domain (no terms).
+    pub supported_ops: Vec<&'static str>,
+}
+
+/// Build the catalog surface description from `eql_scalars::CATALOG`.
+pub fn dump_catalog() -> CatalogDump {
+    let types = CATALOG
+        .iter()
+        .map(|spec| {
+            let domains = spec
+                .domains
+                .iter()
+                .map(|d| DomainEntry {
+                    segment: if d.suffix.is_empty() {
+                        "storage".to_string()
+                    } else {
+                        d.suffix.trim_start_matches('_').to_string()
+                    },
+                    suffix: d.suffix,
+                    supported_ops: Term::operators_for_terms(d.terms),
+                })
+                .collect();
+            TypeEntry {
+                token: spec.token,
+                is_eq_only: spec.is_eq_only(),
+                domains,
+            }
+        })
+        .collect();
+    CatalogDump { types }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn int4_exposes_all_ordered_domains_with_operators() {
+        let dump = dump_catalog();
+        let int4 = dump
+            .types
+            .iter()
+            .find(|t| t.token == "int4")
+            .expect("int4 present in catalog");
+        assert!(!int4.is_eq_only, "int4 is an ordered type");
+
+        let segments: Vec<&str> = int4.domains.iter().map(|d| d.segment.as_str()).collect();
+        assert_eq!(segments, ["storage", "eq", "ord_ore", "ord"]);
+
+        let storage = int4.domains.iter().find(|d| d.segment == "storage").unwrap();
+        assert!(storage.supported_ops.is_empty(), "storage has no operators");
+
+        let eq = int4.domains.iter().find(|d| d.segment == "eq").unwrap();
+        assert_eq!(eq.supported_ops, ["=", "<>"]);
+
+        let ord = int4.domains.iter().find(|d| d.segment == "ord").unwrap();
+        assert_eq!(ord.supported_ops, ["=", "<>", "<", "<=", ">", ">="]);
+    }
+
+    #[test]
+    fn timestamptz_is_eq_only() {
+        let dump = dump_catalog();
+        let ts = dump
+            .types
+            .iter()
+            .find(|t| t.token == "timestamptz")
+            .expect("timestamptz present in catalog");
+        assert!(ts.is_eq_only);
+        let segments: Vec<&str> = ts.domains.iter().map(|d| d.segment.as_str()).collect();
+        assert_eq!(segments, ["storage", "eq"]);
+    }
+}

--- a/crates/eql-codegen/src/lib.rs
+++ b/crates/eql-codegen/src/lib.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 pub mod consts;
 pub mod context;
+pub mod dump;
 pub mod generate;
 pub mod operator_surface;
 pub mod writer;

--- a/crates/eql-codegen/src/main.rs
+++ b/crates/eql-codegen/src/main.rs
@@ -15,6 +15,15 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
 
+    // `dump-catalog`: print the catalog surface (types → domains →
+    // supported operators) as JSON. Consumed by test:matrix:catalog-coverage
+    // (Stage 1) and the log-verification matcher (Stage 4).
+    if args.len() == 2 && args[1] == "dump-catalog" {
+        let dump = eql_codegen::dump::dump_catalog();
+        println!("{}", serde_json::to_string_pretty(&dump).expect("serialize catalog dump"));
+        return ExitCode::SUCCESS;
+    }
+
     if args.len() == 1 {
         // No args: generate every type's gitignored SQL surface.
         match generate_all(&repo_root()) {
@@ -29,5 +38,6 @@ fn main() -> ExitCode {
 
     eprintln!("Usage: eql-codegen            (generate all types)");
     eprintln!("       eql-codegen list-types (print catalog tokens)");
+    eprintln!("       eql-codegen dump-catalog (print catalog surface as JSON)");
     ExitCode::from(2)
 }

--- a/crates/eql-codegen/src/main.rs
+++ b/crates/eql-codegen/src/main.rs
@@ -20,7 +20,10 @@ fn main() -> ExitCode {
     // (Stage 1) and the log-verification matcher (Stage 4).
     if args.len() == 2 && args[1] == "dump-catalog" {
         let dump = eql_codegen::dump::dump_catalog();
-        println!("{}", serde_json::to_string_pretty(&dump).expect("serialize catalog dump"));
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&dump).expect("serialize catalog dump")
+        );
         return ExitCode::SUCCESS;
     }
 

--- a/mise.toml
+++ b/mise.toml
@@ -380,6 +380,116 @@ diff -u snapshots/v3_jsonb_tests.txt "$tmp"
 echo "v3 jsonb inventory OK"
 """
 
+[tasks."test:matrix:catalog-coverage"]
+description = "Assert every CATALOG (type, domain) has matrix tests, cross-checked against the encrypted_domain binary (no database required)"
+dir = "{{config_root}}/tests/sqlx"
+run = """
+#!/usr/bin/env bash
+# Forward catalog-coverage: for each scalar type in the catalog, every domain
+# the catalog declares for it must have at least one matrix test name. FINER
+# than test:matrix:inventory (which reconciles only TYPES against list-types):
+# a DomainSpec added to a catalog row without matrix wiring passes the type
+# inventory but fails here. Domain granularity only (Stage 1); per-operator
+# execution coverage is the Stage 4 matcher's job. No database needed.
+#
+# Compile precondition: encrypted_domain include_str!s its fixtures + the
+# 001 migration at compile time (mise.toml:104). Those are generated/gitignored,
+# so a bare worktree cannot compile it for --list. We never RUN tests here, so
+# empty stub files satisfy include_str!. We create only the missing files (rustc
+# reports them all in one pass) and remove them on exit. Bash 3.2 compatible
+# (macOS): no mapfile/arrays; created stubs are tracked in a temp file.
+set -euo pipefail
+root="{{config_root}}"
+
+# --- DB-free stub preamble so --list can compile on a bare worktree ----------
+created_list=$(mktemp)
+trap 'while IFS= read -r f; do [ -n "$f" ] && rm -f "$f"; done < "$created_list"; rm -f "$created_list"' EXIT
+
+err=$(mktemp)
+i=0
+while :; do
+  if listing=$(cargo test --no-default-features --test encrypted_domain -- --list 2>"$err"); then
+    break
+  fi
+  # Missing include_str! targets are the *.sql paths in the compile errors
+  # (repo-root-relative, may contain `..`). Match path chars only (no backticks
+  # or apostrophes to wrestle through TOML).
+  missing=$(grep -oE "[A-Za-z0-9_./-]+\\.sql" "$err" | LC_ALL=C sort -u || true)
+  if [ -z "$missing" ]; then
+    echo "encrypted_domain failed to list for a non-fixture reason:" >&2
+    cat "$err" >&2
+    rm -f "$err"; exit 1
+  fi
+  while IFS= read -r m; do
+    [ -n "$m" ] || continue
+    p="${root}/${m}"
+    if [ ! -e "$p" ]; then
+      mkdir -p "$(dirname "$p")"
+      : > "$p"
+      echo "$p" >> "$created_list"
+    fi
+  done <<< "$missing"
+  i=$((i + 1))
+  [ "$i" -lt 12 ] || { echo "stub loop exceeded 12 iterations" >&2; cat "$err" >&2; rm -f "$err"; exit 1; }
+done
+rm -f "$err"
+[ -n "$listing" ] || { echo "No tests listed from the encrypted_domain binary." >&2; exit 1; }
+listing=$(printf '%s\\n' "$listing" | sed -n 's/: test$//p')
+
+# --- Catalog surface (overridable for testing via EQL_CATALOG_DUMP_FILE) -----
+# The seam lets the fault-injection check (Step 3) run THIS exact loop against a
+# doctored dump without editing the task.
+if [ -n "${EQL_CATALOG_DUMP_FILE:-}" ]; then
+  dump=$(cat "$EQL_CATALOG_DUMP_FILE")
+else
+  dump=$(cd "$root" && cargo run -q -p eql-codegen -- dump-catalog)
+fi
+
+# --- Forward coverage check --------------------------------------------------
+failed=0
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  # Segments the catalog declares for this type, longest-first so the prefix
+  # exclusion below (ord vs ord_ore) is well-defined.
+  segments=$(printf '%s' "$dump" \
+    | jq -r --arg t "$t" '.types[] | select(.token==$t) | .domains[].segment' \
+    | awk '{ print length, $0 }' | LC_ALL=C sort -rn | cut -d" " -f2-)
+
+  while IFS= read -r seg; do
+    [ -n "$seg" ] || continue
+    # Longer catalog segments having `seg` as a prefix (e.g. ord_ore when seg=ord).
+    longer=$(printf '%s\\n' "$segments" | grep -xvF "$seg" | grep -E "^${seg}_" || true)
+    # (a) Matrix-shape tests: scalars::<t>::matrix_<t>_<seg>_* . The macro emits
+    #     these for the ordered/eq shapes (storage, eq, ord, ord_ore). Strip
+    #     longer-prefix tests so seg=ord does not borrow ord_ore's names.
+    matches=$(printf '%s\\n' "$listing" | grep -E "^scalars::${t}::matrix_${t}_${seg}_" || true)
+    if [ -n "$longer" ]; then
+      while IFS= read -r l; do
+        [ -n "$l" ] || continue
+        matches=$(printf '%s\\n' "$matches" | grep -vE "^scalars::${t}::matrix_${t}_${l}_" || true)
+      done <<< "$longer"
+    fi
+    # (b) Dedicated-module tests: <t>_<seg>::* . Some domains are covered by a
+    #     hand-written suite rather than the matrix macro — text's Bloom `_match`
+    #     domain (`@>`/`<@` containment) lives in the `text_match` module, since
+    #     containment is not an eq/ord shape the matrix emits. The `::` separator
+    #     makes this exact per segment, so no longer-prefix exclusion is needed.
+    module_matches=$(printf '%s\\n' "$listing" | grep -E "^${t}_${seg}::" || true)
+    if [ -z "$(printf '%s' "${matches}${module_matches}" | tr -d '[:space:]')" ]; then
+      echo "MISSING: catalog declares domain '${seg}' for type '${t}', but no scalars::${t}::matrix_${t}_${seg}_* or ${t}_${seg}::* test exists." >&2
+      failed=1
+    fi
+  done <<< "$segments"
+done < <(printf '%s' "$dump" | jq -r '.types[].token')
+
+if [ "$failed" -ne 0 ]; then
+  echo "Catalog-coverage FAILED: a catalog domain has no matrix wiring (see MISSING lines above)." >&2
+  exit 1
+fi
+
+echo "Catalog-coverage OK: every CATALOG (type, domain) has matrix tests."
+"""
+
 [tasks."test:matrix:expand"]
 description = "Regenerate the int4 matrix cargo-expand snapshot (requires the pinned nightly + cargo-expand)"
 dir = "{{config_root}}/tests/sqlx"


### PR DESCRIPTION
## Matrix log verification — Stage 1: static catalog-coverage gate

First of a staged delivery (design: `docs/superpowers/specs/2026-06-12-matrix-log-verification-design.md`). Stage 1 is the **static** half of matrix coverage verification — no database, no capture, pure name-set arithmetic — so it can land and gate CI independently of the heavier capture work.

### What's in it
- **`eql-codegen dump-catalog`** — prints the catalog surface (every scalar type → its generated domains → supported operators) as JSON. The machine-readable "what *should* exist", consumed by the gate here and by the Stage 4 matcher later. (`crates/eql-codegen/src/dump.rs`)
- **`matrix-coverage` CI gate** — cross-checks that every catalog `(domain, operator)` has a corresponding test name in the committed `tests/sqlx/snapshots/matrix_tests.txt`. A silently unwired catalog surface, a dropped/renamed test, or a `#[cfg]`-gated one fails CI. (`mise.toml`, `.github/workflows/test-eql.yml`)

### Verification
- `cargo test -p eql-codegen` (dump/catalog tests green)
- `mise run test:matrix:inventory` (no DB) reconciles the snapshot against `dump-catalog` + the test binary `--list`.

Part of: Stage 1 of 5. Stage 2 (capture + ledger) is stacked on top of this branch.
