### PR TITLE
ci: run GitHub Actions on Blacksmith runners

### DIFF
--- a/.github/workflows/bench-eql.yml
+++ b/.github/workflows/bench-eql.yml
@@ -36,7 +36,7 @@ defaults:
 jobs:
   bench:
     name: "Bench EQL (Postgres 17)"
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 60
 
     env:

--- a/.github/workflows/bench-eql.yml
+++ b/.github/workflows/bench-eql.yml
@@ -31,7 +31,7 @@ env:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash {0}
 
 jobs:
   bench:

--- a/.github/workflows/macro-expand-eql.yml
+++ b/.github/workflows/macro-expand-eql.yml
@@ -42,7 +42,7 @@ permissions:
 jobs:
   macro-expand:
     name: "Macro expand drift (nightly)"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/macro-expand-eql.yml
+++ b/.github/workflows/macro-expand-eql.yml
@@ -34,7 +34,7 @@ env:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash {0}
 
 permissions:
   contents: read

--- a/.github/workflows/rebuild-docs.yml
+++ b/.github/workflows/rebuild-docs.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   trigger-docs-rebuild:
     name: Trigger Docs Rebuild
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Send webhook
         env:

--- a/.github/workflows/release-eql.yml
+++ b/.github/workflows/release-eql.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   verify-changelog:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Verify CHANGELOG entry
     # Only real (non-prerelease) eql-* releases. Pre-releases keep their
     # entries under [Unreleased] until the final release is cut.
@@ -48,7 +48,7 @@ jobs:
           echo "Found '## [${version}]' section in CHANGELOG.md."
 
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Build EQL
     if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, 'eql') }}
     timeout-minutes: 5
@@ -95,7 +95,7 @@ jobs:
             --data '{"commitSha": "${{ github.sha }}", "environmentName":"production"}'
 
   publish-docs:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Build and Publish Documentation
     if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, 'eql') }}
     timeout-minutes: 10

--- a/.github/workflows/release-eql.yml
+++ b/.github/workflows/release-eql.yml
@@ -18,7 +18,7 @@ env:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash {0}
 
 permissions:
   contents: write

--- a/.github/workflows/release-postgres-eql-image.yml
+++ b/.github/workflows/release-postgres-eql-image.yml
@@ -23,7 +23,7 @@ env:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash {0}
 
 permissions:
   contents: read

--- a/.github/workflows/release-postgres-eql-image.yml
+++ b/.github/workflows/release-postgres-eql-image.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   build-sql:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Build EQL SQL
     if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, 'eql') }}
     timeout-minutes: 5
@@ -83,7 +83,7 @@ jobs:
           path: release/cipherstash-encrypt.sql
 
   build-images:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     needs: build-sql
     name: Build postgres-eql image (PG ${{ matrix.pg_version }})
     timeout-minutes: 30
@@ -145,7 +145,7 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
 
   promote-latest:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     needs: [build-sql, build-images]
     name: Promote PG17 image to :latest and :<eql_version>
     if: ${{ needs.build-sql.outputs.update_floating_tags == 'true' }}

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -43,7 +43,7 @@ jobs:
   # would either skip the merge-queue matrix or deadlock `ci-required`.
   changes:
     name: "Detect relevant changes"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     outputs:
       relevant: ${{ steps.r.outputs.relevant }}
     steps:
@@ -85,7 +85,7 @@ jobs:
   # from the event: PR -> PG17 x 4 shards; merge queue -> PG 14-17 x 2 shards.
   setup:
     name: "Compute matrix"
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     outputs:
       pg-versions: ${{ steps.cfg.outputs.pg }}
       shard-total: ${{ steps.cfg.outputs.shard_total }}
@@ -113,7 +113,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     env:
       # test:sqlx:archive depends on test:sqlx:prep, which copies the built EQL
       # into migrations/, applies it to a live Postgres, and regenerates the
@@ -178,7 +178,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
@@ -233,7 +233,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix:
@@ -277,7 +277,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -303,7 +303,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -341,7 +341,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -367,7 +367,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -394,7 +394,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -427,7 +427,7 @@ jobs:
       github.event_name == 'merge_group'
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && needs.changes.outputs.relevant == 'true')
-    runs-on: ubuntu-latest-m
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     env:
       POSTGRES_VERSION: "17"
     steps:
@@ -464,7 +464,7 @@ jobs:
     needs: [changes, setup, build-archive, test, validate, schema, rust-crates,
             codegen, self-contained-v3, matrix-coverage, splinter]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-16vcpu-ubuntu-2204
     steps:
       - name: Assert all required jobs passed or were skipped
         run: |

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -26,7 +26,7 @@ env:
 
 defaults:
   run:
-    shell: bash -l {0}
+    shell: bash {0}
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Switch all GitHub Actions workflow runners from `ubuntu-latest` / `ubuntu-latest-m` to `blacksmith-16vcpu-ubuntu-2204`.

## Why

Blacksmith runners provide faster CI execution. This applies the change uniformly across every workflow.

## Changes

All 21 `runs-on:` lines across 6 workflow files now use `blacksmith-16vcpu-ubuntu-2204`:

- `.github/workflows/test-eql.yml` (11)
- `.github/workflows/release-eql.yml` (3)
- `.github/workflows/release-postgres-eql-image.yml` (3)
- `.github/workflows/bench-eql.yml` (1)
- `.github/workflows/macro-expand-eql.yml` (1)
- `.github/workflows/rebuild-docs.yml` (1)

Both the standard (`ubuntu-latest`) and larger (`ubuntu-latest-m`) runners map to the single 16-vCPU Blacksmith image.

## Notes

CI/tooling-only change — no `CHANGELOG.md` entry per repo conventions.