### PR TITLE
test(v3): type-driven test architecture refactor — uniform catalog-driven matrix

### DIFF
--- a/crates/eql-codegen/src/operator_surface.rs
+++ b/crates/eql-codegen/src/operator_surface.rs
@@ -198,6 +198,34 @@ pub fn operator_function_name(symbol: &str) -> &'static str {
     operator(symbol).function_name
 }
 
+impl Operator {
+    /// True for the native-jsonb operators that every encrypted domain
+    /// generates as BLOCKERS: those that are neither comparison
+    /// (`=`/`<>`/`<`/`<=`/`>`/`>=`), nor containment (`@>`/`<@`), nor
+    /// path-selectors (`->`/`->>`). Derived by exclusion so a 21st operator
+    /// added to `OPERATORS` is automatically classified — no literal list to
+    /// drift out of sync.
+    pub fn is_native_jsonb_blocker(&self) -> bool {
+        const COMPARISON: &[&str] = &["=", "<>", "<", "<=", ">", ">="];
+        const CONTAINMENT: &[&str] = &["@>", "<@"];
+        const PATH_SELECTOR: &[&str] = &["->", "->>"];
+        !COMPARISON.contains(&self.symbol)
+            && !CONTAINMENT.contains(&self.symbol)
+            && !PATH_SELECTOR.contains(&self.symbol)
+    }
+}
+
+/// The native-jsonb operator symbols that every encrypted domain blocks, in
+/// `OPERATORS` order. Source of truth for the matrix's native-jsonb-blocker
+/// arm — the arm asserts its hand-written RHS map's keys equal this set.
+pub fn native_jsonb_blocker_symbols() -> Vec<&'static str> {
+    OPERATORS
+        .iter()
+        .filter(|o| o.is_native_jsonb_blocker())
+        .map(|o| o.symbol)
+        .collect()
+}
+
 /// Comparison-operator metadata (commutator/negator/selectivity estimators).
 const fn cmp_metadata(
     restrict: &'static str,
@@ -574,6 +602,18 @@ mod tests {
                 "=", "<>", "<", "<=", ">", ">=", "@>", "<@", "->", "->>", "?", "?|", "?&", "@?",
                 "@@", "#>", "#>>", "-", "#-", "||"
             ]
+        );
+    }
+
+    #[test]
+    fn native_jsonb_blocker_symbols_are_the_residual_ten() {
+        // The residual after removing the 6 comparison + 2 containment + 2
+        // path-selector ops from the 20-operator catalog. If a 21st operator is
+        // added, classify it (comparison/containment/path-selector/native) and
+        // update this list and the matrix arm's RHS map together.
+        assert_eq!(
+            native_jsonb_blocker_symbols(),
+            vec!["?", "?|", "?&", "@?", "@@", "#>", "#>>", "-", "#-", "||"],
         );
     }
 }

--- a/crates/eql-tests-macros/src/lib.rs
+++ b/crates/eql-tests-macros/src/lib.rs
@@ -181,6 +181,14 @@ fn scalar_type_impls_tokens(list: &ScalarList) -> TokenStream2 {
                     fn fixture_values() -> &'static [#rust_type] {
                         ::eql_scalars::#values
                     }
+
+                    /// Integers draw the full `any::<Self>()` range — the e2e
+                    /// suite's value over the fixture suite is fresh, arbitrary
+                    /// plaintexts, not a re-encryption of the fixed fixture set.
+                    fn arbitrary_value() -> ::proptest::strategy::BoxedStrategy<#rust_type> {
+                        use ::proptest::strategy::Strategy;
+                        ::proptest::prelude::any::<#rust_type>().boxed()
+                    }
                 }
 
                 impl OrderedScalar for #rust_type {

--- a/crates/eql-tests-macros/src/lib.rs
+++ b/crates/eql-tests-macros/src/lib.rs
@@ -184,17 +184,10 @@ fn scalar_type_impls_tokens(list: &ScalarList) -> TokenStream2 {
                 }
 
                 impl OrderedScalar for #rust_type {
-                    /// Integer scalars pivot on their inherent `MIN`/`MAX` consts;
-                    /// the fixture lists include both (`fixtures!(int …; Min, …, Max)`).
-                    fn min_pivot() -> #rust_type {
-                        <#rust_type>::MIN
-                    }
-
-                    fn max_pivot() -> #rust_type {
-                        <#rust_type>::MAX
-                    }
-                    // `mid_pivot` inherits the default `Self::default()` = `0`,
-                    // which is the numeric origin and a `Zero` fixture row.
+                    // Boundary pivots derive from `fixture_values()` (the integer
+                    // fixture lists include `Min`/`Max` = the inherent bounds);
+                    // `mid_pivot` inherits `Self::default()` = `0`. Nothing to
+                    // override.
                 }
 
                 impl SignedScalar for #rust_type {
@@ -439,15 +432,16 @@ mod tests {
         assert!(out.contains(r#"const PG_TYPE : & 'static str = "int8""#));
         assert!(out.contains(":: eql_scalars :: INT4_VALUES"));
         assert!(out.contains(":: eql_scalars :: INT8_VALUES"));
-        // const→fn: fixture values is a method now, plus the integer pivots.
+        // const→fn: fixture values is a method now.
         assert!(out.contains("fn fixture_values"));
-        // Assert the emitted pivot bodies, not bare `MIN`/`MAX` substrings:
-        // the latter also appear in the doc comment, so a loose check would
-        // pass even if the bodies stopped returning the inherent bounds.
-        assert!(out.contains("fn min_pivot () -> i32 { < i32 > :: MIN }"));
-        assert!(out.contains("fn max_pivot () -> i32 { < i32 > :: MAX }"));
-        assert!(out.contains("fn min_pivot () -> i64 { < i64 > :: MIN }"));
-        assert!(out.contains("fn max_pivot () -> i64 { < i64 > :: MAX }"));
+        // Pivots are now derived trait defaults — the emitter writes an empty
+        // `impl OrderedScalar` and no longer spells out the boundary bodies.
+        assert!(out.contains("impl OrderedScalar for i32 { }"));
+        assert!(out.contains("impl OrderedScalar for i64 { }"));
+        assert!(!out.contains("fn min_pivot"));
+        assert!(!out.contains("fn max_pivot"));
+        // `SignedScalar::origin` is still emitted.
+        assert!(out.contains("fn origin () -> i32 { 0 }"));
     }
 
     #[test]

--- a/docs/reference/adding-a-scalar-encrypted-domain-type.md
+++ b/docs/reference/adding-a-scalar-encrypted-domain-type.md
@@ -314,7 +314,7 @@ no live catalog type today) vs `ORDERED_INT_DOMAINS` (→ `[eq, ord]`). (`EQ_ONL
 is currently unused — `timestamptz` was promoted to the ordered shape once the ORE
 comparator generalized to N blocks.) The pivot *sweep* is uniform
 across every ordered type (one canonical snapshot); the signed-only sign-boundary
-test (`SignedScalar`, `int`/`date`) lives outside `scalars::` in
+test (`SignedScalar`, `int2`/`int4`/`int8`/`date`/`timestamptz`) lives outside `scalars::` in
 `encrypted_domain/signed.rs`, so a `text` instantiation of it is a compile error
 and it never enters the inventory snapshot. The `matrix.rs` module header is the
 canonical,

--- a/docs/reference/adding-a-scalar-encrypted-domain-type.md
+++ b/docs/reference/adding-a-scalar-encrypted-domain-type.md
@@ -233,12 +233,17 @@ three divergences (for the ordered `date`):
   over `ScalarType` (`scalar_domains.rs`): **`OrderedScalar`** carries the
   `min_pivot()` / `max_pivot()` boundaries and the interior `mid_pivot()` (default
   `Self::default()`); **`SignedScalar: OrderedScalar`** adds `origin()` (the
-  numeric zero / sign boundary). Integer impls (`min=MIN`, `max=MAX`, `mid`
-  inherits `0`, `origin=0`) are emitted by the proc-macro; the temporal `date`
-  impl returns explicit sentinel dates (`mid` inherits the epoch = `origin()`) and
-  is emitted by the `temporal_values!` declarative macro in `scalar_domains.rs`,
-  which emits the `ScalarType` + `OrderedScalar` + `SignedScalar` impls together
-  (the proc-macro emits only integer impls). `date` is both `OrderedScalar` and
+  numeric zero / sign boundary). `min_pivot()`/`max_pivot()` are **derived** for
+  every kind — the trait default returns the smallest/largest `fixture_values()`
+  entry (`ScalarType` already bounds `Ord + Clone`), so a boundary pivot is a
+  fixture row by construction and cannot drift. **No impl overrides them.** Only
+  `mid_pivot()` is ever overridden: it defaults to `Self::default()` (the numeric
+  origin / epoch — a real fixture for the integer kinds, `date`, `timestamptz`,
+  and `numeric`), and `text` overrides it with a real median fixture because
+  `String::default()` is the degenerate empty string (issue #262). The proc-macro
+  and the `temporal_values!` macro therefore emit an empty `impl OrderedScalar`
+  (defaults inherited) alongside the `SignedScalar { origin }` impl where the kind
+  is signed. `date` is both `OrderedScalar` and
   `SignedScalar`; `text` is `OrderedScalar` only and **hand-written** in
   `scalar_domains.rs` (lexicographic order has no origin, so it overrides
   `mid_pivot()` with a real median fixture rather than the degenerate

--- a/docs/reference/adding-a-scalar-encrypted-domain-type.md
+++ b/docs/reference/adding-a-scalar-encrypted-domain-type.md
@@ -445,8 +445,9 @@ generated-SQL drift is caught before database tests run.
 committed `tests/codegen/reference/<T>/` baseline, generated once and checked in
 (see `tests/codegen/reference/README.md` for the regenerate-and-commit recipe).
 The generator is type-generic, but per-type domain *shapes* differ — ordered
-types carry `_ord`/`_ord_ore` + aggregates, equality-only types (`timestamptz`)
-omit them, and the Bloom `text_match` domain renders `@>`/`<@` as supported
+types (including `timestamptz`) carry `_ord`/`_ord_ore` + aggregates, a
+hypothetical equality-only type (`EQ_ONLY_DOMAINS`) would omit them, and the
+Bloom `text_match` domain renders `@>`/`<@` as supported
 containment operators no ordered type emits — so anchoring every type catches a
 regression in any shape, not just the ordered one. `reference_dirs_match_catalog_tokens`
 (in `crates/eql-codegen/tests/parity.rs`) fails CI if a catalog row has no reference

--- a/tests/sqlx/Cargo.toml
+++ b/tests/sqlx/Cargo.toml
@@ -24,8 +24,10 @@ rust_decimal = "1"
 paste = "1"
 eql-scalars = { path = "../../crates/eql-scalars" }
 eql-tests-macros = { path = "../../crates/eql-tests-macros" }
-
-[dev-dependencies]
+# proptest is a regular dependency (not dev-only): `ScalarType::arbitrary_value`
+# is a non-test trait method returning `proptest::strategy::BoxedStrategy`, so the
+# lib must see proptest when compiled as a normal dependency of the integration
+# test targets (`tests/encrypted_domain`), not just under `cfg(test)`.
 proptest = "1"
 
 [lints]

--- a/tests/sqlx/snapshots/matrix_tests.txt
+++ b/tests/sqlx/snapshots/matrix_tests.txt
@@ -19,6 +19,7 @@ scalars::<T>::matrix_<T>_eq_index_engages_hash
 scalars::<T>::matrix_<T>_eq_lt_blocker
 scalars::<T>::matrix_<T>_eq_lte_blocker
 scalars::<T>::matrix_<T>_eq_native_absent_ops
+scalars::<T>::matrix_<T>_eq_native_jsonb_blockers
 scalars::<T>::matrix_<T>_eq_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_eq_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_eq_neq_pivot_mid_correctness
@@ -87,6 +88,7 @@ scalars::<T>::matrix_<T>_ord_lte_pivot_min_correctness
 scalars::<T>::matrix_<T>_ord_lte_pivot_min_cross_shape
 scalars::<T>::matrix_<T>_ord_lte_supported_null
 scalars::<T>::matrix_<T>_ord_native_absent_ops
+scalars::<T>::matrix_<T>_ord_native_jsonb_blockers
 scalars::<T>::matrix_<T>_ord_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_ord_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_ord_neq_pivot_mid_correctness
@@ -162,6 +164,7 @@ scalars::<T>::matrix_<T>_ord_ore_lte_pivot_min_correctness
 scalars::<T>::matrix_<T>_ord_ore_lte_pivot_min_cross_shape
 scalars::<T>::matrix_<T>_ord_ore_lte_supported_null
 scalars::<T>::matrix_<T>_ord_ore_native_absent_ops
+scalars::<T>::matrix_<T>_ord_ore_native_jsonb_blockers
 scalars::<T>::matrix_<T>_ord_ore_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_ord_ore_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_ord_ore_neq_pivot_mid_correctness
@@ -208,6 +211,7 @@ scalars::<T>::matrix_<T>_storage_gte_blocker
 scalars::<T>::matrix_<T>_storage_lt_blocker
 scalars::<T>::matrix_<T>_storage_lte_blocker
 scalars::<T>::matrix_<T>_storage_native_absent_ops
+scalars::<T>::matrix_<T>_storage_native_jsonb_blockers
 scalars::<T>::matrix_<T>_storage_neq_blocker
 scalars::<T>::matrix_<T>_storage_path_op_blockers
 scalars::<T>::matrix_<T>_storage_payload_check

--- a/tests/sqlx/snapshots/matrix_tests.txt
+++ b/tests/sqlx/snapshots/matrix_tests.txt
@@ -203,6 +203,7 @@ scalars::<T>::matrix_<T>_storage_aggregate_typecheck_max
 scalars::<T>::matrix_<T>_storage_aggregate_typecheck_min
 scalars::<T>::matrix_<T>_storage_contained_by_blocker
 scalars::<T>::matrix_<T>_storage_contains_blocker
+scalars::<T>::matrix_<T>_storage_count_distinct_extractor
 scalars::<T>::matrix_<T>_storage_count_path_cast
 scalars::<T>::matrix_<T>_storage_count_typed_column
 scalars::<T>::matrix_<T>_storage_eq_blocker

--- a/tests/sqlx/snapshots/matrix_tests_eq_only.txt
+++ b/tests/sqlx/snapshots/matrix_tests_eq_only.txt
@@ -19,6 +19,7 @@ scalars::<T>::matrix_<T>_eq_index_engages_hash
 scalars::<T>::matrix_<T>_eq_lt_blocker
 scalars::<T>::matrix_<T>_eq_lte_blocker
 scalars::<T>::matrix_<T>_eq_native_absent_ops
+scalars::<T>::matrix_<T>_eq_native_jsonb_blockers
 scalars::<T>::matrix_<T>_eq_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_eq_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_eq_neq_pivot_mid_correctness
@@ -44,6 +45,7 @@ scalars::<T>::matrix_<T>_storage_gte_blocker
 scalars::<T>::matrix_<T>_storage_lt_blocker
 scalars::<T>::matrix_<T>_storage_lte_blocker
 scalars::<T>::matrix_<T>_storage_native_absent_ops
+scalars::<T>::matrix_<T>_storage_native_jsonb_blockers
 scalars::<T>::matrix_<T>_storage_neq_blocker
 scalars::<T>::matrix_<T>_storage_path_op_blockers
 scalars::<T>::matrix_<T>_storage_payload_check

--- a/tests/sqlx/snapshots/matrix_tests_eq_only.txt
+++ b/tests/sqlx/snapshots/matrix_tests_eq_only.txt
@@ -37,6 +37,7 @@ scalars::<T>::matrix_<T>_storage_aggregate_typecheck_max
 scalars::<T>::matrix_<T>_storage_aggregate_typecheck_min
 scalars::<T>::matrix_<T>_storage_contained_by_blocker
 scalars::<T>::matrix_<T>_storage_contains_blocker
+scalars::<T>::matrix_<T>_storage_count_distinct_extractor
 scalars::<T>::matrix_<T>_storage_count_path_cast
 scalars::<T>::matrix_<T>_storage_count_typed_column
 scalars::<T>::matrix_<T>_storage_eq_blocker

--- a/tests/sqlx/snapshots/matrix_tests_text.txt
+++ b/tests/sqlx/snapshots/matrix_tests_text.txt
@@ -289,6 +289,7 @@ scalars::<T>::matrix_<T>_storage_aggregate_typecheck_max
 scalars::<T>::matrix_<T>_storage_aggregate_typecheck_min
 scalars::<T>::matrix_<T>_storage_contained_by_blocker
 scalars::<T>::matrix_<T>_storage_contains_blocker
+scalars::<T>::matrix_<T>_storage_count_distinct_extractor
 scalars::<T>::matrix_<T>_storage_count_path_cast
 scalars::<T>::matrix_<T>_storage_count_typed_column
 scalars::<T>::matrix_<T>_storage_eq_blocker

--- a/tests/sqlx/snapshots/matrix_tests_text.txt
+++ b/tests/sqlx/snapshots/matrix_tests_text.txt
@@ -19,6 +19,7 @@ scalars::<T>::matrix_<T>_eq_index_engages_hash
 scalars::<T>::matrix_<T>_eq_lt_blocker
 scalars::<T>::matrix_<T>_eq_lte_blocker
 scalars::<T>::matrix_<T>_eq_native_absent_ops
+scalars::<T>::matrix_<T>_eq_native_jsonb_blockers
 scalars::<T>::matrix_<T>_eq_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_eq_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_eq_neq_pivot_mid_correctness
@@ -88,6 +89,7 @@ scalars::<T>::matrix_<T>_ord_lte_pivot_min_correctness
 scalars::<T>::matrix_<T>_ord_lte_pivot_min_cross_shape
 scalars::<T>::matrix_<T>_ord_lte_supported_null
 scalars::<T>::matrix_<T>_ord_native_absent_ops
+scalars::<T>::matrix_<T>_ord_native_jsonb_blockers
 scalars::<T>::matrix_<T>_ord_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_ord_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_ord_neq_pivot_mid_correctness
@@ -164,6 +166,7 @@ scalars::<T>::matrix_<T>_ord_ore_lte_pivot_min_correctness
 scalars::<T>::matrix_<T>_ord_ore_lte_pivot_min_cross_shape
 scalars::<T>::matrix_<T>_ord_ore_lte_supported_null
 scalars::<T>::matrix_<T>_ord_ore_native_absent_ops
+scalars::<T>::matrix_<T>_ord_ore_native_jsonb_blockers
 scalars::<T>::matrix_<T>_ord_ore_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_ord_ore_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_ord_ore_neq_pivot_mid_correctness
@@ -256,6 +259,7 @@ scalars::<T>::matrix_<T>_search_match_contains_self
 scalars::<T>::matrix_<T>_search_match_disjoint_miss
 scalars::<T>::matrix_<T>_search_match_index_engages_gin
 scalars::<T>::matrix_<T>_search_native_absent_ops
+scalars::<T>::matrix_<T>_search_native_jsonb_blockers
 scalars::<T>::matrix_<T>_search_neq_pivot_max_correctness
 scalars::<T>::matrix_<T>_search_neq_pivot_max_cross_shape
 scalars::<T>::matrix_<T>_search_neq_pivot_mid_correctness
@@ -293,6 +297,7 @@ scalars::<T>::matrix_<T>_storage_gte_blocker
 scalars::<T>::matrix_<T>_storage_lt_blocker
 scalars::<T>::matrix_<T>_storage_lte_blocker
 scalars::<T>::matrix_<T>_storage_native_absent_ops
+scalars::<T>::matrix_<T>_storage_native_jsonb_blockers
 scalars::<T>::matrix_<T>_storage_neq_blocker
 scalars::<T>::matrix_<T>_storage_path_op_blockers
 scalars::<T>::matrix_<T>_storage_payload_check

--- a/tests/sqlx/src/jsonb_entry.rs
+++ b/tests/sqlx/src/jsonb_entry.rs
@@ -97,15 +97,10 @@ impl ScalarType for JsonbEntryInt4 {
 }
 
 impl OrderedScalar for JsonbEntryInt4 {
-    fn min_pivot() -> Self {
-        JsonbEntryInt4(<i32 as OrderedScalar>::min_pivot())
-    }
-    fn max_pivot() -> Self {
-        JsonbEntryInt4(<i32 as OrderedScalar>::max_pivot())
-    }
-    fn mid_pivot() -> Self {
-        JsonbEntryInt4(<i32 as OrderedScalar>::mid_pivot())
-    }
+    // All three pivots inherit the `OrderedScalar` defaults: the boundaries
+    // derive from `fixture_values()` (wrapped `INT4_VALUES`) and `mid_pivot`
+    // inherits `JsonbEntryInt4::default()` = `JsonbEntryInt4(0)`. This is exactly
+    // the int4 delegation that used to be spelled out here.
 }
 
 // `JsonbEntryInt4` is deliberately NOT `SignedScalar` — the entry suite does

--- a/tests/sqlx/src/jsonb_entry.rs
+++ b/tests/sqlx/src/jsonb_entry.rs
@@ -94,6 +94,14 @@ impl ScalarType for JsonbEntryInt4 {
     fn ord_extractor_expr(value_expr: &str) -> String {
         format!("eql_v3.ore_cllw({value_expr})")
     }
+
+    // Not an e2e/property-oracle type (the entry suite runs the jsonb_entry
+    // matrix, not the value oracle), but `arbitrary_value` is a required
+    // `ScalarType` method — sample the wrapped int4 fixtures.
+    fn arbitrary_value() -> proptest::strategy::BoxedStrategy<Self> {
+        use proptest::strategy::Strategy;
+        proptest::sample::select(Self::fixture_values().to_vec()).boxed()
+    }
 }
 
 impl OrderedScalar for JsonbEntryInt4 {

--- a/tests/sqlx/src/matrix.rs
+++ b/tests/sqlx/src/matrix.rs
@@ -3379,12 +3379,11 @@ macro_rules! __scalar_matrix_count_case {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __scalar_matrix_count_distinct_dispatch {
-    // Storage: no DISTINCT case — no extractor to deduplicate by.
-    (
-        suite = $suite:ident, scalar = $scalar:ty, script = $script:literal, script_path = $script_path:literal,
-        dom_name = $dom_name:ident, variant = Storage $(,)?
-    ) => {};
-    // Eq, Ord, OrdOre — emit the DISTINCT test.
+    // One arm for EVERY variant — the Storage-vs-rest decision is a RUNTIME
+    // `extractor_expr().is_none()` early-return inside the body, NOT a
+    // macro-expansion ident-match on `Storage`. (A `macro_rules!` cannot suppress
+    // a test item at runtime, so Storage emits a trivially-passing test rather
+    // than emitting nothing — see Task 6C.)
     (
         suite = $suite:ident, scalar = $scalar:ty, script = $script:literal, script_path = $script_path:literal,
         dom_name = $dom_name:ident, variant = $variant:ident $(,)?
@@ -3397,8 +3396,12 @@ macro_rules! __scalar_matrix_count_distinct_dispatch {
                 use $crate::scalar_domains::ScalarType;
                 let spec = $crate::__scalar_matrix_spec!($scalar, $variant);
                 let d = &spec.sql_domain;
-                let extractor = spec.extractor_expr("value")
-                    .expect("non-Storage variant must expose an extractor");
+                let Some(extractor) = spec.extractor_expr("value") else {
+                    // Storage has no extractor to deduplicate by — the count-distinct
+                    // case is meaningless here, so this emitted test is a trivial pass.
+                    // (Runtime guard, NOT a macro ident-match: that is the point of 6C.)
+                    return Ok(());
+                };
                 let fixture = <$scalar as ScalarType>::fixture_table_name();
                 let expected = <$scalar as ScalarType>::fixture_values().len() as i64;
 

--- a/tests/sqlx/src/matrix.rs
+++ b/tests/sqlx/src/matrix.rs
@@ -1267,33 +1267,6 @@ macro_rules! __scalar_matrix_native_absent_case {
 pub const NATIVE_JSONB_BLOCKER_ARM_SYMBOLS: &[&str] =
     &["?", "?|", "?&", "@?", "@@", "#>", "#>>", "-", "#-", "||"];
 
-#[cfg(test)]
-mod native_jsonb_blocker_arm_tests {
-    use super::*;
-
-    #[test]
-    fn native_jsonb_blocker_arm_covers_every_derived_symbol() {
-        // The arm's hand-written RHS-shape map keys (operator SYMBOLS) must equal
-        // the codegen residual. `eql-codegen` is not a dependency of this crate,
-        // so we pin against the same literal 10-symbol vector that
-        // `native_jsonb_blocker_symbols_are_the_residual_ten`
-        // (operator_surface.rs) pins against the live `OPERATORS` table. The two
-        // pins together fail if either side drifts: a 21st native-jsonb operator
-        // makes the codegen test fail, and updating that test without updating
-        // this const makes them disagree on review. The RHS operand shapes stay
-        // hand-written; only the symbol SET is asserted.
-        let mut arm: Vec<&str> = NATIVE_JSONB_BLOCKER_ARM_SYMBOLS.to_vec();
-        let mut want = vec!["?", "?|", "?&", "@?", "@@", "#>", "#>>", "-", "#-", "||"];
-        arm.sort_unstable();
-        want.sort_unstable();
-        assert_eq!(
-            arm, want,
-            "native-jsonb-blocker arm symbol set must equal the codegen residual; \
-             arm={NATIVE_JSONB_BLOCKER_ARM_SYMBOLS:?}",
-        );
-    }
-}
-
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __scalar_matrix_native_jsonb_blocker_outer {
@@ -3449,4 +3422,31 @@ macro_rules! __scalar_matrix_count_distinct_dispatch {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod native_jsonb_blocker_arm_tests {
+    use super::*;
+
+    #[test]
+    fn native_jsonb_blocker_arm_covers_every_derived_symbol() {
+        // The arm's hand-written RHS-shape map keys (operator SYMBOLS) must equal
+        // the codegen residual. `eql-codegen` is not a dependency of this crate,
+        // so we pin against the same literal 10-symbol vector that
+        // `native_jsonb_blocker_symbols_are_the_residual_ten`
+        // (operator_surface.rs) pins against the live `OPERATORS` table. The two
+        // pins together fail if either side drifts: a 21st native-jsonb operator
+        // makes the codegen test fail, and updating that test without updating
+        // this const makes them disagree on review. The RHS operand shapes stay
+        // hand-written; only the symbol SET is asserted.
+        let mut arm: Vec<&str> = NATIVE_JSONB_BLOCKER_ARM_SYMBOLS.to_vec();
+        let mut want = vec!["?", "?|", "?&", "@?", "@@", "#>", "#>>", "-", "#-", "||"];
+        arm.sort_unstable();
+        want.sort_unstable();
+        assert_eq!(
+            arm, want,
+            "native-jsonb-blocker arm symbol set must equal the codegen residual; \
+             arm={NATIVE_JSONB_BLOCKER_ARM_SYMBOLS:?}",
+        );
+    }
 }

--- a/tests/sqlx/src/matrix.rs
+++ b/tests/sqlx/src/matrix.rs
@@ -4,11 +4,13 @@
 //!
 //! - **`scalar_matrix!`** — the recommended wrapper. One invocation per type
 //!   (~5 lines), with a `caps` capability marker selecting the shape:
-//!   `caps = [eq, ord]` for an ordered scalar (i32, i64, date, ...) where all
-//!   four variants are present and the full `=`/`<>`/`<`/`>`/`min`/`max`
-//!   surface applies; `caps = [eq]` for an equality-only scalar (timestamptz,
-//!   bool, ...) where only storage + `_eq` materialise and the ord operators
-//!   are blockers. The only other inputs that change per type are the scalar
+//!   `caps = [eq, ord]` for an ordered scalar (i32, i64, date, timestamptz,
+//!   ...) where all four variants are present and the full
+//!   `=`/`<>`/`<`/`>`/`min`/`max` surface applies; `caps = [eq]` for a
+//!   hypothetical equality-only scalar (e.g. a future hash-only type) where
+//!   only storage + `_eq` materialise and the ord operators are blockers — no
+//!   current type uses this shape. The only other inputs that change per type
+//!   are the scalar
 //!   itself, the suite token (used to derive domain + test names), and the EQL
 //!   type name (the fixture `scripts(...)` ref); pivots are derived from the
 //!   `ScalarType` impl.
@@ -146,11 +148,13 @@ fn collect_index_scan_nodes(value: &serde_json::Value, found: &mut Vec<(String, 
 ///
 /// - `caps = [eq, ord]` — the ordered-numeric shape (all four variants;
 ///   `=`/`<>`/`<`/`<=`/`>`/`>=`; ORDER BY / ORDER BY USING; ORE injectivity;
-///   the ordered functional index). Consumers: `int2`/`int4`/`int8`/`date`.
+///   the ordered functional index). Consumers:
+///   `int2`/`int4`/`int8`/`date`/`timestamptz`/`numeric`.
 /// - `caps = [eq]` — equality-only (storage + `_eq` only; `=`/`<>` meaningful,
 ///   the four ord operators are deliberate blockers). The empty `ord_domains`
-///   make the order-by / ORE arms emit zero tests. First consumer:
-///   `timestamptz`.
+///   make the order-by / ORE arms emit zero tests. No current consumer —
+///   `timestamptz` was promoted to the ordered shape once the N-block ORE
+///   comparator could order its native 12-block width.
 ///
 /// Both arms take the identical `(suite, scalar, eql_type)` signature, so the
 /// invocation shape is the same regardless of capability — only the `caps`

--- a/tests/sqlx/src/matrix.rs
+++ b/tests/sqlx/src/matrix.rs
@@ -1242,12 +1242,13 @@ macro_rules! __scalar_matrix_native_absent_case {
 // Native-jsonb-blocker category — the native jsonb operators that the codegen
 // surface generates as BLOCKERS on every encrypted domain (neither comparison,
 // containment, nor path-selector). They must RAISE the EQL "operator X is not
-// supported" blocker on every variant, with PLACEHOLDER_PAYLOAD (no fixture
-// row needed — see the "blocker raises before decryption" note in the
-// Critical-context section). Per-op RHS shapes mirror the native jsonb operator
-// signatures (see crates/eql-codegen/src/operator_surface.rs OPERATORS):
-// `?`/`-` take text, `?|`/`?&`/`#>`/`#>>`/`#-` take text[], `@?`/`@@` take
-// jsonpath, `||` takes jsonb. Replaces the int4-only
+// supported" blocker on every variant, with PLACEHOLDER_PAYLOAD. No fixture row
+// is needed: the blocker resolves on the operator and raises before any payload
+// is read, so any castable sentinel suffices. Per-op RHS shapes mirror the
+// native jsonb operator signatures (see
+// crates/eql-codegen/src/operator_surface.rs OPERATORS): `?` takes text, `-`
+// takes text / integer / text[] (three overloads), `?|`/`?&`/`#>`/`#>>`/`#-`
+// take text[], `@?`/`@@` take jsonpath, `||` takes jsonb. Replaces the int4-only
 // `omitted_native_jsonb_operators_raise_eql_blockers` hand-written test,
 // extending the guarantee to all storage scalars.
 //
@@ -1365,6 +1366,24 @@ macro_rules! __scalar_matrix_native_jsonb_blocker_case {
                         &pool, &sql, &[Some(payload), Some(payload)], &concat_msg,
                     ).await?;
                 }
+
+                // Guard: the symbols this arm actually sweeps (the `single` op
+                // keys plus `||`) must equal NATIVE_JSONB_BLOCKER_ARM_SYMBOLS,
+                // itself pinned to the codegen residual by a sibling #[test]. This
+                // ties the SQL the arm runs to the pinned set, so a symbol added
+                // to the const without a matching `single`/`concat` case (or vice
+                // versa) fails here instead of silently going unexercised.
+                let mut swept: Vec<&str> = single.iter().map(|(op, _)| *op).collect();
+                swept.push("||");
+                swept.sort_unstable();
+                swept.dedup();
+                let mut pinned: Vec<&str> =
+                    $crate::matrix::NATIVE_JSONB_BLOCKER_ARM_SYMBOLS.to_vec();
+                pinned.sort_unstable();
+                anyhow::ensure!(
+                    swept == pinned,
+                    "native-jsonb-blocker arm swept {swept:?} but pinned set is {pinned:?}",
+                );
                 Ok(())
             }
         }

--- a/tests/sqlx/src/matrix.rs
+++ b/tests/sqlx/src/matrix.rs
@@ -605,6 +605,10 @@ macro_rules! scalar_domain_matrix {
             suite = $suite, scalar = $scalar,
             domains = [$(($all_name, $all_variant)),+],
         }
+        $crate::__scalar_matrix_native_jsonb_blocker_outer! {
+            suite = $suite, scalar = $scalar,
+            domains = [$(($all_name, $all_variant)),+],
+        }
         $crate::__scalar_matrix_typed_column_outer! {
             suite = $suite, scalar = $scalar,
             combos = [$($blocker_combo),+],
@@ -931,7 +935,11 @@ macro_rules! __scalar_matrix_cross_shape_case {
 
 // ============================================================================
 // Supported-NULL category — leaf for the domain × op driver: STRICT wrappers
-// must propagate NULL on all three NULL positions (left, right, both).
+// must propagate NULL on all three NULL positions (left, right, both). This is
+// three-valued logic — a supported op (e.g. `<>`) with a NULL operand must
+// yield NULL, not true and not false; easy to get wrong in domain wrappers,
+// which is why every (domain, op) pair is swept here. (Subsumes the deleted
+// `neq_propagates_null_under_three_valued_logic` int4 hand-test.)
 // ============================================================================
 
 #[macro_export]
@@ -1218,6 +1226,139 @@ macro_rules! __scalar_matrix_native_absent_case {
                         &pool, &sql,
                         &[Some(payload), Some(payload)],
                         "operator does not exist",
+                    ).await?;
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+// ============================================================================
+// Native-jsonb-blocker category — the native jsonb operators that the codegen
+// surface generates as BLOCKERS on every encrypted domain (neither comparison,
+// containment, nor path-selector). They must RAISE the EQL "operator X is not
+// supported" blocker on every variant, with PLACEHOLDER_PAYLOAD (no fixture
+// row needed — see the "blocker raises before decryption" note in the
+// Critical-context section). Per-op RHS shapes mirror the native jsonb operator
+// signatures (see crates/eql-codegen/src/operator_surface.rs OPERATORS):
+// `?`/`-` take text, `?|`/`?&`/`#>`/`#>>`/`#-` take text[], `@?`/`@@` take
+// jsonpath, `||` takes jsonb. Replaces the int4-only
+// `omitted_native_jsonb_operators_raise_eql_blockers` hand-written test,
+// extending the guarantee to all storage scalars.
+//
+// The SYMBOL SET this arm sweeps is pinned to the codegen-derived residual by
+// `native_jsonb_blocker_arm_covers_every_derived_symbol` (below) via
+// `NATIVE_JSONB_BLOCKER_ARM_SYMBOLS` — the RHS operand shapes stay hand-written.
+// ============================================================================
+
+/// The operator symbols the `__scalar_matrix_native_jsonb_blocker_*` arm
+/// sweeps, in `OPERATORS` order. The RHS operand *shapes* are hand-written in
+/// the macro body (they cannot be derived from the symbol), but this symbol
+/// SET must stay equal to the codegen-derived residual
+/// (`eql_codegen::operator_surface::native_jsonb_blocker_symbols()`, pinned by
+/// `native_jsonb_blocker_symbols_are_the_residual_ten` in that crate) — pinned
+/// here by `native_jsonb_blocker_arm_covers_every_derived_symbol`.
+pub const NATIVE_JSONB_BLOCKER_ARM_SYMBOLS: &[&str] =
+    &["?", "?|", "?&", "@?", "@@", "#>", "#>>", "-", "#-", "||"];
+
+#[cfg(test)]
+mod native_jsonb_blocker_arm_tests {
+    use super::*;
+
+    #[test]
+    fn native_jsonb_blocker_arm_covers_every_derived_symbol() {
+        // The arm's hand-written RHS-shape map keys (operator SYMBOLS) must equal
+        // the codegen residual. `eql-codegen` is not a dependency of this crate,
+        // so we pin against the same literal 10-symbol vector that
+        // `native_jsonb_blocker_symbols_are_the_residual_ten`
+        // (operator_surface.rs) pins against the live `OPERATORS` table. The two
+        // pins together fail if either side drifts: a 21st native-jsonb operator
+        // makes the codegen test fail, and updating that test without updating
+        // this const makes them disagree on review. The RHS operand shapes stay
+        // hand-written; only the symbol SET is asserted.
+        let mut arm: Vec<&str> = NATIVE_JSONB_BLOCKER_ARM_SYMBOLS.to_vec();
+        let mut want = vec!["?", "?|", "?&", "@?", "@@", "#>", "#>>", "-", "#-", "||"];
+        arm.sort_unstable();
+        want.sort_unstable();
+        assert_eq!(
+            arm, want,
+            "native-jsonb-blocker arm symbol set must equal the codegen residual; \
+             arm={NATIVE_JSONB_BLOCKER_ARM_SYMBOLS:?}",
+        );
+    }
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __scalar_matrix_native_jsonb_blocker_outer {
+    (
+        suite = $suite:ident, scalar = $scalar:ty,
+        domains = [$(($dom_name:ident, $variant:ident)),+ $(,)?] $(,)?
+    ) => {
+        $(
+            $crate::__scalar_matrix_native_jsonb_blocker_case! {
+                suite = $suite, scalar = $scalar,
+                dom_name = $dom_name, variant = $variant,
+            }
+        )+
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __scalar_matrix_native_jsonb_blocker_case {
+    (
+        suite = $suite:ident, scalar = $scalar:ty,
+        dom_name = $dom_name:ident, variant = $variant:ident $(,)?
+    ) => {
+        $crate::paste::paste! {
+            #[sqlx::test]
+            async fn [<matrix_ $suite _ $dom_name _native_jsonb_blockers>](
+                pool: sqlx::PgPool,
+            ) -> anyhow::Result<()> {
+                let spec = $crate::__scalar_matrix_spec!($scalar, $variant);
+                let d = &spec.sql_domain;
+                let payload = $crate::helpers::PLACEHOLDER_PAYLOAD;
+
+                // (op symbol, full SELECT-able expr). The LHS is always
+                // `$1::jsonb::{d}`. `-` carries three arg shapes (text / integer /
+                // text[]) and `||` three overloads — covering every generated
+                // overload exactly as the int4 hand-test did. Each binds one
+                // PLACEHOLDER_PAYLOAD. The swept symbol set is pinned to the
+                // codegen residual by NATIVE_JSONB_BLOCKER_ARM_SYMBOLS.
+                let single: &[(&str, String)] = &[
+                    ("?",   format!("$1::jsonb::{d} ? 'c'::text")),
+                    ("?|",  format!("$1::jsonb::{d} ?| ARRAY['c']")),
+                    ("?&",  format!("$1::jsonb::{d} ?& ARRAY['c']")),
+                    ("#>",  format!("$1::jsonb::{d} #> ARRAY['i']")),
+                    ("#>>", format!("$1::jsonb::{d} #>> ARRAY['i', 'c']")),
+                    ("@?",  format!("$1::jsonb::{d} @? '$.c'::jsonpath")),
+                    ("@@",  format!("$1::jsonb::{d} @@ '$.c == \"placeholder\"'::jsonpath")),
+                    ("-",   format!("$1::jsonb::{d} - 'c'::text")),
+                    ("-",   format!("$1::jsonb::{d} - 0")),
+                    ("-",   format!("$1::jsonb::{d} - ARRAY['c']")),
+                    ("#-",  format!("$1::jsonb::{d} #- ARRAY['i']")),
+                ];
+                for (op, expr) in single {
+                    let sql = format!("SELECT {expr}");
+                    let msg = $crate::scalar_domains::blocker_msg(d, op);
+                    $crate::scalar_domains::assert_raises(
+                        &pool, &sql, &[Some(payload)], &msg,
+                    ).await?;
+                }
+
+                // `||` overloads: (domain, jsonb), (jsonb, domain), (domain, domain).
+                let concat: &[String] = &[
+                    format!("$1::jsonb::{d} || $2::jsonb"),
+                    format!("$1::jsonb || $2::jsonb::{d}"),
+                    format!("$1::jsonb::{d} || $2::jsonb::{d}"),
+                ];
+                let concat_msg = $crate::scalar_domains::blocker_msg(d, "||");
+                for expr in concat {
+                    let sql = format!("SELECT {expr}");
+                    $crate::scalar_domains::assert_raises(
+                        &pool, &sql, &[Some(payload), Some(payload)], &concat_msg,
                     ).await?;
                 }
                 Ok(())

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -127,6 +127,22 @@ pub trait ScalarType:
         values.sort();
         values
     }
+
+    /// A proptest strategy producing fresh plaintexts for the e2e oracle.
+    ///
+    /// The e2e suite encrypts each generated value end-to-end through ZeroKMS,
+    /// so the strategy MUST only produce values the type's EQL cast accepts.
+    ///
+    /// Required (not defaulted on purpose): a `where Self: Arbitrary` bound on a
+    /// provided default leaks into the method's contract for EVERY caller —
+    /// including the generic `T: ScalarType` oracle drivers — so `String` /
+    /// `Decimal` / `NaiveDate` (not `Arbitrary`) could never satisfy it, even
+    /// though they override the body. Making it required keeps the bound off the
+    /// signature. Integers supply the full `any::<Self>()` range (proc-macro
+    /// generated, in `eql-tests-macros`); non-integer scalars sample their
+    /// cast-valid fixture set — the only bounded strategy `Arbitrary` can't give
+    /// them, and always cast-valid because every fixture already round-trips.
+    fn arbitrary_value() -> proptest::strategy::BoxedStrategy<Self>;
 }
 
 /// An **ordered** scalar — one whose `_ord` domains support `<`/`<=`/`>`/`>=`.
@@ -262,6 +278,14 @@ macro_rules! temporal_values {
             fn to_sql_literal(value: &$ty) -> String {
                 let f: fn(&$ty) -> String = $sql_lit;
                 f(value)
+            }
+            fn arbitrary_value() -> proptest::strategy::BoxedStrategy<$ty> {
+                use proptest::strategy::Strategy;
+                // Sample the catalog fixture values — every one is cast-valid and
+                // already exercised by the fixture suite; the e2e novelty is that
+                // the SAME plaintext is independently re-encrypted, which the
+                // duplicate-injection in run_e2e_property guarantees.
+                proptest::sample::select($accessor().to_vec()).boxed()
             }
         }
 
@@ -472,6 +496,11 @@ impl ScalarType for String {
     fn to_sql_literal(value: &Self) -> String {
         format!("'{}'", value.replace('\'', "''"))
     }
+
+    fn arbitrary_value() -> proptest::strategy::BoxedStrategy<Self> {
+        use proptest::strategy::Strategy;
+        proptest::sample::select(text_values().to_vec()).boxed()
+    }
 }
 
 impl OrderedScalar for String {
@@ -546,6 +575,11 @@ impl ScalarType for rust_decimal::Decimal {
     // `to_sql_literal` inherits the default (`value.to_string()`): a `Decimal`'s
     // `Display` form (e.g. `-1000000000000`, `0.001`) is a valid SQL numeric
     // literal, so no quoting/override is needed (unlike `text` / `date`).
+
+    fn arbitrary_value() -> proptest::strategy::BoxedStrategy<Self> {
+        use proptest::strategy::Strategy;
+        proptest::sample::select(numeric_values().to_vec()).boxed()
+    }
 }
 
 impl OrderedScalar for rust_decimal::Decimal {
@@ -631,6 +665,14 @@ impl ScalarType for bool {
     }
     // `to_sql_literal` inherits the default (`value.to_string()` => `true`/`false`),
     // which is a valid SQL boolean literal, so no override is needed.
+
+    // `bool` is storage-only and never feeds an oracle suite, but `arbitrary_value`
+    // is a required `ScalarType` method, so sample its two fixtures like every
+    // other non-integer scalar.
+    fn arbitrary_value() -> proptest::strategy::BoxedStrategy<Self> {
+        use proptest::strategy::Strategy;
+        proptest::sample::select(bool_values().to_vec()).boxed()
+    }
 }
 
 // `bool` is deliberately NOT `OrderedScalar` / `SignedScalar` / `MatchScalar`:
@@ -1302,6 +1344,34 @@ mod pivot_derivation_tests {
         boundary_pivots_are_fixture_extremes::<chrono::DateTime<chrono::Utc>>();
         boundary_pivots_are_fixture_extremes::<rust_decimal::Decimal>();
         boundary_pivots_are_fixture_extremes::<String>();
+    }
+}
+
+#[cfg(test)]
+mod arbitrary_value_tests {
+    use super::*;
+    use proptest::strategy::Strategy;
+    use proptest::test_runner::TestRunner;
+
+    fn draws_a_value<T: ScalarType>() {
+        let strat = T::arbitrary_value();
+        let mut runner = TestRunner::default();
+        // A single successful draw proves the strategy is wired and non-empty.
+        let tree = strat
+            .new_tree(&mut runner)
+            .expect("arbitrary_value strategy must produce a value");
+        let _v: T = proptest::strategy::ValueTree::current(&tree);
+    }
+
+    #[test]
+    fn every_ordered_scalar_has_a_working_value_strategy() {
+        draws_a_value::<i16>();
+        draws_a_value::<i32>();
+        draws_a_value::<i64>();
+        draws_a_value::<chrono::NaiveDate>();
+        draws_a_value::<chrono::DateTime<chrono::Utc>>();
+        draws_a_value::<rust_decimal::Decimal>();
+        draws_a_value::<String>();
     }
 }
 

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -225,8 +225,9 @@ crate::scalar_types!(scalar_type_impls);
 /// a `#[cfg(test)]` module asserting the parsed values track the catalog and
 /// include the pivots. The chrono analogue of `eql_scalars::int_values!`
 /// (integers materialise a `const` slice; temporals can't, so values live in a
-/// `LazyLock`). `parse`/`min_pivot`/`max_pivot`/`sql_lit` are expressions so each
-/// type supplies its own chrono parsing, sentinel pivots, and SQL literal form.
+/// `LazyLock`). `parse`/`sql_lit` are expressions so each type supplies its own
+/// chrono parsing and SQL literal form. Boundary pivots are not parameters: they
+/// derive from `fixture_values()` via the `OrderedScalar` defaults.
 macro_rules! temporal_values {
     (
         cell      = $cell:ident,

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -1396,7 +1396,15 @@ mod oracle_inventory_tests {
             .collect();
         assert_eq!(
             ordered,
-            vec!["int4", "int2", "int8", "date", "timestamptz", "numeric", "text"],
+            vec![
+                "int4",
+                "int2",
+                "int8",
+                "date",
+                "timestamptz",
+                "numeric",
+                "text"
+            ],
         );
         // bool is storage-only: no ordered domain, so it is excluded.
         assert!(!ordered.contains(&"bool"));
@@ -1422,7 +1430,15 @@ mod oracle_inventory_tests {
         // instantiation lists.
         assert_eq!(
             ordered,
-            vec!["int4", "int2", "int8", "date", "timestamptz", "numeric", "text"],
+            vec![
+                "int4",
+                "int2",
+                "int8",
+                "date",
+                "timestamptz",
+                "numeric",
+                "text"
+            ],
             "a new ordered scalar must be wired into BOTH oracle suites \
              (fixture_oracle.rs and e2e_oracle.rs)"
         );

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -309,6 +309,40 @@ macro_rules! temporal_values {
     };
 }
 
+/// Materialise a scalar's catalog fixtures into a `LazyLock<Vec<$ty>>` plus a
+/// public accessor, parsing each `Fixture` via the supplied closure. The
+/// kind-agnostic core shared by every non-integer scalar: `temporal_values!`
+/// adds the chrono-specific `ScalarType`/`OrderedScalar`/`SignedScalar` wiring on
+/// top, while `text`/`numeric` supply their own (they are not signed). Integer
+/// scalars do not use this — they materialise a `const` slice in `eql-scalars`
+/// (`int_values!`) and impl `ScalarType` via the proc-macro.
+///
+/// `$variant` is the `eql_scalars::Fixture` variant this scalar's rows use
+/// (`Text`/`Numeric`/`Date`/`Timestamptz`); `$parse` maps each `&Fixture` to
+/// `$ty` (and owns its own loud "wrong variant" panic). The accessor is `pub` so
+/// the `eql_v2_<T>` fixture module can hand the slice to `scalar_fixture!`.
+macro_rules! lazy_values {
+    (
+        cell      = $cell:ident,
+        accessor  = $accessor:ident,
+        rust_type = $ty:ty,
+        spec      = $spec:path,
+        variant   = $variant:ident,
+        pg_type   = $pg:literal,
+        parse     = $parse:expr $(,)?
+    ) => {
+        static $cell: std::sync::LazyLock<Vec<$ty>> = std::sync::LazyLock::new(|| {
+            let parse: fn(&::eql_scalars::Fixture) -> $ty = $parse;
+            $spec.fixtures.iter().map(parse).collect()
+        });
+
+        #[doc = concat!("Typed `", stringify!($ty), "` fixtures for `", $pg, "`, materialised once from the catalog.")]
+        pub fn $accessor() -> &'static [$ty] {
+            &$cell
+        }
+    };
+}
+
 // `date`'s `ScalarType` wiring is generated from its catalog row by
 // `temporal_values!` — the chrono analogue of the integer `int_values!` path.
 // Values can't be a `const` slice (`from_ymd_opt` is not `const`), so they live

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -142,13 +142,27 @@ pub trait ScalarType:
 /// (e.g. `String`, whose `Default` is the degenerate empty string) override it
 /// with a real median fixture.
 pub trait OrderedScalar: ScalarType {
-    /// The low boundary pivot. Integer scalars return `Self::MIN`; others an
-    /// explicit sentinel. Present verbatim in `fixture_values()`.
-    fn min_pivot() -> Self;
+    /// The low boundary pivot — the smallest `fixture_values()` entry. Derived
+    /// (the `ScalarType` supertrait bounds `Ord + Clone`), so it is a fixture
+    /// row by construction and cannot drift out of the fixture table. No impl
+    /// overrides this.
+    fn min_pivot() -> Self {
+        Self::fixture_values()
+            .iter()
+            .min()
+            .expect("an ordered scalar must have at least one fixture value")
+            .clone()
+    }
 
-    /// The high boundary pivot. Integer scalars return `Self::MAX`; others an
-    /// explicit sentinel. Present verbatim in `fixture_values()`.
-    fn max_pivot() -> Self;
+    /// The high boundary pivot — the largest `fixture_values()` entry. Derived,
+    /// like `min_pivot()`. No impl overrides this.
+    fn max_pivot() -> Self {
+        Self::fixture_values()
+            .iter()
+            .max()
+            .expect("an ordered scalar must have at least one fixture value")
+            .clone()
+    }
 
     /// The interior pivot. Defaults to `Self::default()` (the numeric origin for
     /// signed scalars); override where `Default` is not a usable fixture anchor.
@@ -222,8 +236,6 @@ macro_rules! temporal_values {
         variant   = $variant:ident,
         pg_type   = $pg:literal,
         parse     = $parse:expr,
-        min_pivot = $min:expr,
-        max_pivot = $max:expr,
         sql_lit   = $sql_lit:expr $(,)?
     ) => {
         static $cell: std::sync::LazyLock<Vec<$ty>> = std::sync::LazyLock::new(|| {
@@ -253,11 +265,9 @@ macro_rules! temporal_values {
         }
 
         impl OrderedScalar for $ty {
-            fn min_pivot() -> $ty { $min }
-            fn max_pivot() -> $ty { $max }
-            // `mid_pivot` inherits the default `Self::default()`. Every chrono
-            // temporal type's `Default` is the epoch (`1970-01-01` for a date),
-            // which is also `origin()` — a real fixture and the sign boundary.
+            // Boundary pivots derive from `fixture_values()`; `mid_pivot`
+            // inherits `Self::default()` (the epoch), which is `origin()` and a
+            // real fixture. Nothing to override.
         }
 
         impl SignedScalar for $ty {
@@ -313,8 +323,6 @@ temporal_values! {
     pg_type   = "date",
     parse     = |s| chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
         .expect("catalog date fixture must be YYYY-MM-DD"),
-    min_pivot = chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("1900-01-01 valid"),
-    max_pivot = chrono::NaiveDate::from_ymd_opt(2099, 12, 31).expect("2099-12-31 valid"),
     sql_lit   = |v| format!("'{v}'"),
 }
 
@@ -334,12 +342,6 @@ temporal_values! {
     parse     = |s| chrono::DateTime::parse_from_rfc3339(s)
         .expect("catalog timestamptz fixture must be RFC3339")
         .with_timezone(&chrono::Utc),
-    min_pivot = "1900-01-01T00:00:00Z"
-        .parse()
-        .expect("1900-01-01T00:00:00Z is a valid timestamp"),
-    max_pivot = "2099-12-31T23:59:59Z"
-        .parse()
-        .expect("2099-12-31T23:59:59Z is a valid timestamp"),
     sql_lit   = |v| format!("'{}'", v.to_rfc3339()),
 }
 
@@ -439,22 +441,10 @@ impl ScalarType for String {
 }
 
 impl OrderedScalar for String {
-    /// Lexicographic min pivot — the lexicographically-smallest fixture
-    /// (`"aard"`). Present verbatim in `fixture_values()`; keep in sync with
-    /// `TEXT_FIXTURES`.
-    fn min_pivot() -> Self {
-        "aard".to_string()
-    }
-
-    /// Lexicographic max pivot — the lexicographically-largest fixture
-    /// (`"zzzz"`).
-    fn max_pivot() -> Self {
-        "zzzz".to_string()
-    }
-
     /// Interior pivot — a real median fixture. `String::default()` is `""`,
     /// which is degenerate for ORE (issue #262), so `text` overrides the
-    /// inherited default with a genuine middle value.
+    /// inherited default with a genuine middle value. The boundary pivots are
+    /// inherited (derived from `fixture_values()` = `"aard"`/`"zzzz"`).
     fn mid_pivot() -> Self {
         "frank".to_string()
     }
@@ -524,19 +514,9 @@ impl ScalarType for rust_decimal::Decimal {
 }
 
 impl OrderedScalar for rust_decimal::Decimal {
-    /// The smallest fixture decimal. Present verbatim in `fixture_values()`.
-    fn min_pivot() -> Self {
-        use std::str::FromStr;
-        rust_decimal::Decimal::from_str("-1000000000000").unwrap()
-    }
-
-    /// The largest fixture decimal. Present verbatim in `fixture_values()`.
-    fn max_pivot() -> Self {
-        use std::str::FromStr;
-        rust_decimal::Decimal::from_str("1000000000000").unwrap()
-    }
-    // `mid_pivot` inherits the default `Self::default()` = `Decimal::ZERO` = 0,
-    // which is a real fixture and the numeric origin.
+    // Boundary pivots derive from `fixture_values()` (= ±1_000_000_000_000);
+    // `mid_pivot` inherits `Decimal::ZERO` (`Default`), a real fixture and the
+    // numeric origin. Nothing to override.
 }
 
 // `Decimal` is deliberately NOT `SignedScalar`: like `text`, it is an
@@ -564,6 +544,16 @@ mod numeric_value_guards {
             vals.len(),
             "two numeric fixtures alias to the same Decimal value",
         );
+    }
+
+    /// `mid_pivot` is the only pivot `numeric` does not derive (it inherits
+    /// `Decimal::ZERO`). The matrix fetches its ciphertext via
+    /// `fetch_fixture_payload`, so `0` must be a fixture row present verbatim.
+    #[test]
+    fn mid_pivot_is_a_fixture() {
+        let values = numeric_values();
+        let mid = <rust_decimal::Decimal as OrderedScalar>::mid_pivot();
+        assert!(values.contains(&mid), "numeric mid_pivot {mid:?} must be a fixture");
     }
 }
 
@@ -1236,5 +1226,35 @@ mod catalog_resolution_tests {
         // `@>` is not served by any extractor on int4 `_eq` ([Hm]).
         let spec = ScalarDomainSpec::new::<i32>(Variant::Eq);
         assert!(combo_extractor(&spec, &["@>"]).is_err());
+    }
+}
+
+#[cfg(test)]
+mod pivot_derivation_tests {
+    use super::*;
+
+    /// The invariant that lets `min_pivot`/`max_pivot` be DERIVED from
+    /// `fixture_values()` instead of hand-written: for every ordered scalar the
+    /// boundary pivots equal the extremes of its own fixture list. Passes with
+    /// the current hand-written pivots (they already equal the extremes) and
+    /// keeps passing once the trait derives them — so it guards the refactor in
+    /// both directions.
+    fn boundary_pivots_are_fixture_extremes<T: OrderedScalar>() {
+        let values = T::fixture_values();
+        let want_min = values.iter().min().expect("≥1 fixture").clone();
+        let want_max = values.iter().max().expect("≥1 fixture").clone();
+        assert_eq!(T::min_pivot(), want_min, "min_pivot must be the smallest fixture");
+        assert_eq!(T::max_pivot(), want_max, "max_pivot must be the largest fixture");
+    }
+
+    #[test]
+    fn every_ordered_scalar_pivots_on_its_fixture_extremes() {
+        boundary_pivots_are_fixture_extremes::<i16>();
+        boundary_pivots_are_fixture_extremes::<i32>();
+        boundary_pivots_are_fixture_extremes::<i64>();
+        boundary_pivots_are_fixture_extremes::<chrono::NaiveDate>();
+        boundary_pivots_are_fixture_extremes::<chrono::DateTime<chrono::Utc>>();
+        boundary_pivots_are_fixture_extremes::<rust_decimal::Decimal>();
+        boundary_pivots_are_fixture_extremes::<String>();
     }
 }

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -1401,4 +1401,30 @@ mod oracle_inventory_tests {
         // bool is storage-only: no ordered domain, so it is excluded.
         assert!(!ordered.contains(&"bool"));
     }
+
+    /// Drift guard: the ordered-scalar set below is the EXACT list that must
+    /// appear as `fixture_oracle_suite!(…, ordered)` in `fixture_oracle.rs` AND
+    /// `e2e_oracle_suite!(…)` in `e2e_oracle.rs`. Those macro lists live in the
+    /// test binary and cannot be introspected from here, so this test pins the
+    /// expected set; a new ordered scalar added to CATALOG fails here until both
+    /// suite lists are updated. (The matrix tier has its own gate:
+    /// `mise run test:matrix:inventory`.)
+    #[test]
+    fn ordered_scalars_requiring_oracle_wiring() {
+        // Same `is_declared_for` guard as above: `supports_ord` panics on a
+        // scalar with no `_ord` domain (bool), so short-circuit first.
+        let ordered: Vec<&str> = CATALOG
+            .iter()
+            .filter(|s| Variant::Ord.is_declared_for(s.token) && Variant::Ord.supports_ord(s.token))
+            .map(|s| s.token)
+            .collect();
+        // Keep in lockstep with the fixture_oracle_suite! / e2e_oracle_suite!
+        // instantiation lists.
+        assert_eq!(
+            ordered,
+            vec!["int4", "int2", "int8", "date", "timestamptz", "numeric", "text"],
+            "a new ordered scalar must be wired into BOTH oracle suites \
+             (fixture_oracle.rs and e2e_oracle.rs)"
+        );
+    }
 }

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -441,24 +441,23 @@ mod timestamptz_value_guards {
 // `text_values()` is public so the `eql_v2_text` fixture module (emitted by
 // `scalar_types!(fixture_modules)`) can hand the slice to `scalar_fixture!`.
 
-/// Typed `String` fixture values, built once from `text`'s catalog row.
-/// `eql_scalars::TEXT_VALUES` is a `&[&'static str]` const, but the `ScalarType`
-/// contract returns `&[Self]` = `&[String]` (owned), so we materialise them into
-/// a `LazyLock<Vec<String>>` and return a borrow — the same shape as
-/// `date_values`. (Unlike `date`, no parsing is needed; the values are the
-/// strings verbatim.)
-static TEXT_VALUES_CELL: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
-    eql_scalars::TEXT_VALUES
-        .iter()
-        .map(|s| s.to_string())
-        .collect()
-});
-
-/// The `String` fixture values, in catalog order. Public so the `eql_v2_text`
-/// fixture module (emitted by `scalar_types!(fixture_modules)`) can hand the
-/// slice to `scalar_fixture!`.
-pub fn text_values() -> &'static [String] {
-    &TEXT_VALUES_CELL
+// `text`'s value wiring now goes through the shared `lazy_values!` materializer
+// (the same macro `numeric` uses), parsing the catalog's `Fixture::Text` rows
+// directly. `text_values()` stays public so the `eql_v2_text` fixture module
+// (emitted by `scalar_types!(fixture_modules)`) can hand the slice to
+// `scalar_fixture!`. The `to_sql_literal` / `mid_pivot` / `MatchScalar` methods
+// below are `text`'s genuinely-differing bits and remain hand-written.
+lazy_values! {
+    cell      = TEXT_VALUES_CELL,
+    accessor  = text_values,
+    rust_type = String,
+    spec      = eql_scalars::TEXT,
+    variant   = Text,
+    pg_type   = "text",
+    parse     = |f| match f {
+        eql_scalars::Fixture::Text(s) => s.to_string(),
+        other => panic!("non-text fixture in text catalog row: {other:?}"),
+    },
 }
 
 impl ScalarType for String {

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -554,7 +554,10 @@ mod numeric_value_guards {
     fn mid_pivot_is_a_fixture() {
         let values = numeric_values();
         let mid = <rust_decimal::Decimal as OrderedScalar>::mid_pivot();
-        assert!(values.contains(&mid), "numeric mid_pivot {mid:?} must be a fixture");
+        assert!(
+            values.contains(&mid),
+            "numeric mid_pivot {mid:?} must be a fixture"
+        );
     }
 }
 
@@ -1244,8 +1247,16 @@ mod pivot_derivation_tests {
         let values = T::fixture_values();
         let want_min = values.iter().min().expect("≥1 fixture").clone();
         let want_max = values.iter().max().expect("≥1 fixture").clone();
-        assert_eq!(T::min_pivot(), want_min, "min_pivot must be the smallest fixture");
-        assert_eq!(T::max_pivot(), want_max, "max_pivot must be the largest fixture");
+        assert_eq!(
+            T::min_pivot(),
+            want_min,
+            "min_pivot must be the smallest fixture"
+        );
+        assert_eq!(
+            T::max_pivot(),
+            want_max,
+            "max_pivot must be the largest fixture"
+        );
     }
 
     #[test]

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -514,26 +514,27 @@ impl MatchScalar for String {
 // a `LazyLock<Vec<Decimal>>` rather than going through `temporal_values!`. The
 // catalog stays zero-dep, so the parse happens here, not in `eql-scalars`.
 
-/// Typed `Decimal` fixture values, parsed once from `numeric`'s catalog row.
-static NUMERIC_VALUES_CELL: std::sync::LazyLock<Vec<rust_decimal::Decimal>> =
-    std::sync::LazyLock::new(|| {
-        use std::str::FromStr;
-        eql_scalars::NUMERIC
-            .fixtures
-            .iter()
-            .map(|f| match f {
-                eql_scalars::Fixture::Numeric(s) => rust_decimal::Decimal::from_str(s)
-                    .unwrap_or_else(|e| panic!("invalid numeric catalog fixture {s:?}: {e}")),
-                other => panic!("non-numeric fixture in numeric catalog row: {other:?}"),
-            })
-            .collect()
-    });
-
-/// The `Decimal` fixture values, in catalog order. Public so the `eql_v2_numeric`
-/// fixture module (emitted by `scalar_types!(fixture_modules)`) can hand the
-/// slice to `scalar_fixture!`.
-pub fn numeric_values() -> &'static [rust_decimal::Decimal] {
-    &NUMERIC_VALUES_CELL
+// `numeric`'s value wiring goes through the shared `lazy_values!` materializer
+// (same as `text`), parsing the catalog's `Fixture::Numeric` strings into
+// `Decimal`. `numeric_values()` stays public so the `eql_v2_numeric` fixture
+// module (emitted by `scalar_types!(fixture_modules)`) can hand the slice to
+// `scalar_fixture!`. `numeric` has no `to_sql_literal`/`mid_pivot` overrides —
+// only the value materialization is shared.
+lazy_values! {
+    cell      = NUMERIC_VALUES_CELL,
+    accessor  = numeric_values,
+    rust_type = rust_decimal::Decimal,
+    spec      = eql_scalars::NUMERIC,
+    variant   = Numeric,
+    pg_type   = "numeric",
+    parse     = |f| match f {
+        eql_scalars::Fixture::Numeric(s) => {
+            use std::str::FromStr;
+            rust_decimal::Decimal::from_str(s)
+                .unwrap_or_else(|e| panic!("invalid numeric catalog fixture {s:?}: {e}"))
+        }
+        other => panic!("non-numeric fixture in numeric catalog row: {other:?}"),
+    },
 }
 
 impl ScalarType for rust_decimal::Decimal {

--- a/tests/sqlx/src/scalar_domains.rs
+++ b/tests/sqlx/src/scalar_domains.rs
@@ -1270,3 +1270,31 @@ mod pivot_derivation_tests {
         boundary_pivots_are_fixture_extremes::<String>();
     }
 }
+
+#[cfg(test)]
+mod oracle_inventory_tests {
+    use super::*;
+    use eql_scalars::CATALOG;
+
+    /// The set of catalog tokens that should get an `eq` + `ord` fixture/e2e
+    /// oracle suite is exactly the ordered (non-storage-only) scalars. Pin it so
+    /// the catalog-driven suite macros (fixture_oracle / e2e_oracle) cannot drift
+    /// from the catalog. `bool` is storage-only and must be excluded.
+    #[test]
+    fn ordered_scalar_tokens_match_catalog() {
+        // `supports_ord` calls `terms_for`, which PANICS on an undeclared
+        // (token, suffix) pair, so guard with `is_declared_for` first — bool has
+        // no `_ord` domain and must short-circuit to false, not panic.
+        let ordered: Vec<&str> = CATALOG
+            .iter()
+            .filter(|s| Variant::Ord.is_declared_for(s.token) && Variant::Ord.supports_ord(s.token))
+            .map(|s| s.token)
+            .collect();
+        assert_eq!(
+            ordered,
+            vec!["int4", "int2", "int8", "date", "timestamptz", "numeric", "text"],
+        );
+        // bool is storage-only: no ordered domain, so it is excluded.
+        assert!(!ordered.contains(&"bool"));
+    }
+}

--- a/tests/sqlx/tests/encrypted_domain/family/support.rs
+++ b/tests/sqlx/tests/encrypted_domain/family/support.rs
@@ -4,9 +4,7 @@
 //! depends on.
 
 use anyhow::Result;
-use eql_tests::{
-    sql_string_literal, ScalarDomainSpec, ScalarType, Variant, PLACEHOLDER_PAYLOAD,
-};
+use eql_tests::{sql_string_literal, ScalarDomainSpec, ScalarType, Variant, PLACEHOLDER_PAYLOAD};
 use sqlx::PgPool;
 
 #[test]

--- a/tests/sqlx/tests/encrypted_domain/family/support.rs
+++ b/tests/sqlx/tests/encrypted_domain/family/support.rs
@@ -5,7 +5,6 @@
 
 use anyhow::Result;
 use eql_tests::{
-    assert_null, assert_raises, assert_scalar_plaintexts, blocker_msg, fetch_fixture_payload,
     sql_string_literal, ScalarDomainSpec, ScalarType, Variant, PLACEHOLDER_PAYLOAD,
 };
 use sqlx::PgPool;
@@ -114,213 +113,28 @@ fn sql_string_literal_escapes_single_quotes() {
     assert_eq!(sql_string_literal("abc'def"), "'abc''def'");
 }
 
-#[sqlx::test(fixtures(path = "../../../fixtures", scripts("eql_v2_int4")))]
-async fn fetch_fixture_payload_returns_keyed_row(pool: PgPool) -> Result<()> {
-    // Parse the payload as JSON rather than substring-matching — whitespace
-    // and key ordering in the serialised form are not contract.
-    let payload = fetch_fixture_payload::<i32>(&pool, 42).await?;
-    let value: serde_json::Value = serde_json::from_str(&payload)?;
-    assert_eq!(value["v"], serde_json::json!(2), "payload must carry v=2");
-    assert!(value.get("c").is_some(), "payload must carry a c field");
-    Ok(())
-}
-
-#[sqlx::test(fixtures(path = "../../../fixtures", scripts("eql_v2_int4")))]
-async fn assert_scalar_plaintexts_reports_sql_context(pool: PgPool) -> Result<()> {
-    let lit = sql_string_literal(&fetch_fixture_payload::<i32>(&pool, 42).await?);
-    let predicate = format!("payload::eql_v3.int4_ord_ore = {lit}::jsonb::eql_v3.int4_ord_ore");
-    assert_scalar_plaintexts::<i32>(&pool, "eql_v3.int4_ord_ore", "=", &predicate, &[42]).await?;
-    Ok(())
-}
-
 #[sqlx::test]
-async fn placeholder_payload_satisfies_every_variant_check(pool: PgPool) -> Result<()> {
+async fn placeholder_payload_casts_to_every_declared_domain(pool: PgPool) -> Result<()> {
     // The whole point of PLACEHOLDER_PAYLOAD: one sentinel that casts
-    // successfully to every domain in the family. If a variant CHECK
-    // tightens, this test fails and PLACEHOLDER_PAYLOAD needs updating.
+    // successfully to EVERY declared domain of EVERY live scalar type. If a
+    // variant CHECK tightens for any type, this fails and PLACEHOLDER_PAYLOAD
+    // needs updating. Catalog-driven so a new scalar type is covered the
+    // moment its CATALOG row lands — no per-type edit here.
     //
-    // Iterates `Variant::ALL` for `i32`, deriving each domain name from
-    // `ScalarDomainSpec::new::<i32>(variant).sql_domain` rather than
-    // hardcoding the names. Currently `i32`-only; when `int8` (or any
-    // future scalar) lands, wrap this in a per-type loop so the
-    // PLACEHOLDER_PAYLOAD cast is exercised against every scalar.
-    for variant in Variant::ALL {
-        // int4 does not declare every variant (no `_search`); skip the ones it
-        // lacks so the cast targets a real domain.
-        if !variant.is_declared_for("int4") {
-            continue;
+    // (Was i32-only with a TODO to generalize; the TODO is now done.)
+    use eql_scalars::CATALOG;
+    for spec in CATALOG {
+        for domain in spec.domains {
+            let sql_domain = format!("eql_v3.{}{}", spec.token, domain.suffix);
+            let sql = format!("SELECT $1::jsonb::{sql_domain}");
+            sqlx::query(&sql)
+                .bind(PLACEHOLDER_PAYLOAD)
+                .fetch_one(&pool)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!("PLACEHOLDER_PAYLOAD must cast to {sql_domain}: {e}")
+                })?;
         }
-        let spec = ScalarDomainSpec::new::<i32>(*variant);
-        let sql = format!("SELECT $1::jsonb::{}", spec.sql_domain);
-        sqlx::query(&sql)
-            .bind(PLACEHOLDER_PAYLOAD)
-            .fetch_one(&pool)
-            .await
-            .map_err(|e| {
-                anyhow::anyhow!("PLACEHOLDER_PAYLOAD must cast to {}: {e}", spec.sql_domain)
-            })?;
-    }
-    Ok(())
-}
-
-#[sqlx::test]
-async fn assert_raises_two_bind_blocker(pool: PgPool) -> Result<()> {
-    let msg = blocker_msg("eql_v3.int4", "=");
-    assert_raises(
-        &pool,
-        "SELECT $1::jsonb::eql_v3.int4 = $2::jsonb::eql_v3.int4",
-        &[Some(PLACEHOLDER_PAYLOAD), Some(PLACEHOLDER_PAYLOAD)],
-        &msg,
-    )
-    .await
-}
-
-#[sqlx::test]
-async fn assert_raises_one_bind_path_blocker(pool: PgPool) -> Result<()> {
-    let msg = blocker_msg("eql_v3.int4", "->");
-    assert_raises(
-        &pool,
-        "SELECT $1::jsonb::eql_v3.int4 -> 'field'::text",
-        &[Some(PLACEHOLDER_PAYLOAD)],
-        &msg,
-    )
-    .await
-}
-
-#[sqlx::test]
-async fn assert_raises_native_operator_absent(pool: PgPool) -> Result<()> {
-    // ~~ (LIKE) isn't declared on int4 — error message is PG's native
-    // "operator does not exist", not an EQL blocker message.
-    assert_raises(
-        &pool,
-        "SELECT $1::jsonb::eql_v3.int4 ~~ $2::jsonb::eql_v3.int4",
-        &[Some(PLACEHOLDER_PAYLOAD), Some(PLACEHOLDER_PAYLOAD)],
-        "operator does not exist",
-    )
-    .await
-}
-
-#[sqlx::test]
-async fn omitted_native_jsonb_operators_raise_eql_blockers(pool: PgPool) -> Result<()> {
-    let cases: &[(&str, &[Option<&str>], &str)] = &[
-        (
-            "SELECT $1::jsonb::eql_v3.int4 ? 'c'::text",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "?",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 ?| ARRAY['c']",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "?|",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 ?& ARRAY['c']",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "?&",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 #> ARRAY['i']",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "#>",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 #>> ARRAY['i', 'c']",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "#>>",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 @? '$.c'::jsonpath",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "@?",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 @@ '$.c == \"placeholder\"'::jsonpath",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "@@",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 - 'c'::text",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "-",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 - 0",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "-",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 - ARRAY['c']",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "-",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 #- ARRAY['i']",
-            &[Some(PLACEHOLDER_PAYLOAD)],
-            "#-",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 || $2::jsonb",
-            &[Some(PLACEHOLDER_PAYLOAD), Some(PLACEHOLDER_PAYLOAD)],
-            "||",
-        ),
-        (
-            "SELECT $1::jsonb || $2::jsonb::eql_v3.int4",
-            &[Some(PLACEHOLDER_PAYLOAD), Some(PLACEHOLDER_PAYLOAD)],
-            "||",
-        ),
-        (
-            "SELECT $1::jsonb::eql_v3.int4 || $2::jsonb::eql_v3.int4",
-            &[Some(PLACEHOLDER_PAYLOAD), Some(PLACEHOLDER_PAYLOAD)],
-            "||",
-        ),
-    ];
-
-    for (sql, binds, op) in cases {
-        assert_raises(&pool, sql, binds, &blocker_msg("eql_v3.int4", op)).await?;
-    }
-    Ok(())
-}
-
-#[sqlx::test]
-async fn assert_raises_engages_on_all_null(pool: PgPool) -> Result<()> {
-    // Non-STRICT blocker proof — must raise even with NULL on both sides.
-    let msg = blocker_msg("eql_v3.int4", "=");
-    assert_raises(
-        &pool,
-        "SELECT $1::jsonb::eql_v3.int4 = $2::jsonb::eql_v3.int4",
-        &[None, None],
-        &msg,
-    )
-    .await
-}
-
-#[sqlx::test]
-async fn assert_null_propagates_through_supported_op(pool: PgPool) -> Result<()> {
-    // STRICT supported op with one NULL operand yields NULL.
-    assert_null(
-        &pool,
-        "SELECT $1::jsonb::eql_v3.int4_eq = $2::jsonb::eql_v3.int4_eq",
-        &[Some(PLACEHOLDER_PAYLOAD), None],
-    )
-    .await
-}
-
-#[sqlx::test]
-async fn neq_propagates_null_under_three_valued_logic(pool: PgPool) -> Result<()> {
-    // `<>` with a NULL operand must yield NULL (not true, not false).
-    // Three-valued logic is easy to get wrong in domain wrappers; a
-    // STRICT supported `<>` returns NULL on either NULL side.
-    for binds in [
-        &[Some(PLACEHOLDER_PAYLOAD), None][..],
-        &[None, Some(PLACEHOLDER_PAYLOAD)][..],
-        &[None, None][..],
-    ] {
-        assert_null(
-            &pool,
-            "SELECT $1::jsonb::eql_v3.int4_eq <> $2::jsonb::eql_v3.int4_eq",
-            binds,
-        )
-        .await?;
     }
     Ok(())
 }

--- a/tests/sqlx/tests/encrypted_domain/property/README.md
+++ b/tests/sqlx/tests/encrypted_domain/property/README.md
@@ -48,8 +48,12 @@ querying. Gated behind the `proptest-e2e` cargo feature — `mise run test:sqlx`
 enables it (CI has the secrets); a bare `cargo test` compiles it out. It is the
 **only** suite that can exercise "same plaintext, *different* ciphertext"
 (equality across independently-encrypted values), because the committed fixture
-corpus has no duplicate plaintexts. Integer scalars only for now (random `T`
-generation is trivial for integers).
+corpus has no duplicate plaintexts. Covers every ordered scalar
+(int2/int4/int8/date/timestamptz/numeric/text) via the
+`ScalarType::arbitrary_value()` strategy seam — integers draw the full
+`any::<T>()` range, non-integer scalars sample their cast-valid fixture set
+(their plaintexts have no usable bounded `Arbitrary`). `bool` is storage-only
+(no ordered domain) and is the only scalar excluded.
 
 ## The shared oracle engine
 

--- a/tests/sqlx/tests/encrypted_domain/property/e2e_oracle.rs
+++ b/tests/sqlx/tests/encrypted_domain/property/e2e_oracle.rs
@@ -9,7 +9,7 @@
 
 use anyhow::Result;
 use eql_tests::fixtures::cipherstash::{column_config_for, encrypt_store};
-use eql_tests::fixtures::eql_plaintext::{Cast, EqlPlaintext};
+use eql_tests::fixtures::eql_plaintext::EqlPlaintext;
 use eql_tests::fixtures::index_kind::IndexKind;
 use eql_tests::property::{
     assert_eq_oracle, assert_ord_oracle, connect_pool, ensure_eql_installed, Row,
@@ -20,13 +20,15 @@ use proptest::prelude::*;
 use proptest::test_runner::{Config, TestCaseError, TestRunner};
 use sqlx::PgPool;
 
-/// Encrypt a batch of plaintext integers into `(plaintext, payload_json)` rows
+/// Encrypt a batch of plaintext values into `(plaintext, payload_json)` rows
 /// via the existing fixture oracle. One ZeroKMS round trip for the whole batch.
-async fn encrypt_rows<T>(pool_table: &str, cast: Cast, values: &[T]) -> Result<Vec<Row<T>>>
+/// The EQL cast is the type's own `EqlPlaintext::CAST` — never passed in, so it
+/// cannot drift from `T`.
+async fn encrypt_rows<T>(pool_table: &str, values: &[T]) -> Result<Vec<Row<T>>>
 where
     T: ScalarType + EqlPlaintext + Clone,
 {
-    let config = column_config_for(&[IndexKind::Unique, IndexKind::Ore], cast)?;
+    let config = column_config_for(&[IndexKind::Unique, IndexKind::Ore], <T as EqlPlaintext>::CAST)?;
     let payloads = encrypt_store(pool_table, "payload", values, &config).await?;
     // Fail fast on a count mismatch: a silent `zip` truncation would weaken the
     // oracle (fewer pairs than intended) and hide an encrypt_store contract
@@ -52,7 +54,6 @@ where
 /// encryption + oracle is async on a current-thread runtime.
 fn run_e2e_property<T>(
     table: &str,
-    cast: Cast,
     cases: u32,
     ordered: bool,
     seeds: &[T],
@@ -96,7 +97,7 @@ where
             values.push(dup0);
             values.push(dup1);
             let rows = rt
-                .block_on(encrypt_rows::<T>(table, cast, &values))
+                .block_on(encrypt_rows::<T>(table, &values))
                 // `{e:#}` keeps anyhow's full cause chain (the underlying error),
                 // which a plain `{e}` would drop.
                 .map_err(|e| TestCaseError::fail(format!("encrypt: {e:#}")))?;
@@ -114,36 +115,21 @@ where
         .map_err(|e| anyhow::anyhow!("e2e property failed: {e}"))
 }
 
-#[test]
-fn prop_int4_eq_and_ord_oracle_e2e() -> Result<()> {
-    // Low case count: each case is a ZeroKMS round trip. 8 keeps CI bounded.
-    run_e2e_property::<i32>(
-        "proptest_e2e_int4",
-        Cast::INT,
-        8,
-        true,
-        &[i32::MIN, 0, i32::MAX],
-    )
+/// Each e2e case is a ZeroKMS round trip, so the case count stays low (8 keeps
+/// CI bounded). One macro line per ordered scalar; the EQL cast is derived from
+/// the type, the seeds are the per-type extremes + origin.
+macro_rules! e2e_oracle_suite {
+    ($modname:ident, $ty:ty, $table:literal, seeds = [$($seed:expr),* $(,)?]) => {
+        mod $modname {
+            use super::*;
+            #[test]
+            fn e2e_oracle() -> Result<()> {
+                run_e2e_property::<$ty>($table, 8, true, &[$($seed),*])
+            }
+        }
+    };
 }
 
-#[test]
-fn prop_int2_eq_and_ord_oracle_e2e() -> Result<()> {
-    run_e2e_property::<i16>(
-        "proptest_e2e_int2",
-        Cast::SMALL_INT,
-        8,
-        true,
-        &[i16::MIN, 0, i16::MAX],
-    )
-}
-
-#[test]
-fn prop_int8_eq_and_ord_oracle_e2e() -> Result<()> {
-    run_e2e_property::<i64>(
-        "proptest_e2e_int8",
-        Cast::BIG_INT,
-        8,
-        true,
-        &[i64::MIN, 0, i64::MAX],
-    )
-}
+e2e_oracle_suite!(int4, i32, "proptest_e2e_int4", seeds = [i32::MIN, 0, i32::MAX]);
+e2e_oracle_suite!(int2, i16, "proptest_e2e_int2", seeds = [i16::MIN, 0, i16::MAX]);
+e2e_oracle_suite!(int8, i64, "proptest_e2e_int8", seeds = [i64::MIN, 0, i64::MAX]);

--- a/tests/sqlx/tests/encrypted_domain/property/e2e_oracle.rs
+++ b/tests/sqlx/tests/encrypted_domain/property/e2e_oracle.rs
@@ -60,8 +60,6 @@ fn run_e2e_property<T>(
 ) -> Result<()>
 where
     T: ScalarType + EqlPlaintext + Clone + 'static,
-    T: proptest::arbitrary::Arbitrary,
-    <T as proptest::arbitrary::Arbitrary>::Strategy: 'static,
 {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
@@ -88,7 +86,9 @@ where
     // of the first two random values. Seeds guarantee min/max/zero coverage;
     // duplicates guarantee the eq-true branch across independently encrypted
     // ciphertexts.
-    let strategy = prop::collection::vec(any::<T>(), 2..11);
+    // Per-type bounded strategy (see ScalarType::arbitrary_value): integers draw
+    // the full range, non-integer scalars draw from their cast-valid fixture set.
+    let strategy = prop::collection::vec(T::arbitrary_value(), 2..11);
     runner
         .run(&strategy, |mut values| {
             let dup0 = values[0].clone();
@@ -133,3 +133,23 @@ macro_rules! e2e_oracle_suite {
 e2e_oracle_suite!(int4, i32, "proptest_e2e_int4", seeds = [i32::MIN, 0, i32::MAX]);
 e2e_oracle_suite!(int2, i16, "proptest_e2e_int2", seeds = [i16::MIN, 0, i16::MAX]);
 e2e_oracle_suite!(int8, i64, "proptest_e2e_int8", seeds = [i64::MIN, 0, i64::MAX]);
+e2e_oracle_suite!(date, chrono::NaiveDate, "proptest_e2e_date",
+    seeds = [
+        chrono::NaiveDate::from_ymd_opt(1900, 1, 1).unwrap(),
+        chrono::NaiveDate::default(),
+        chrono::NaiveDate::from_ymd_opt(2099, 12, 31).unwrap(),
+    ]);
+e2e_oracle_suite!(timestamptz, chrono::DateTime<chrono::Utc>, "proptest_e2e_timestamptz",
+    seeds = [
+        chrono::DateTime::parse_from_rfc3339("1900-01-01T00:00:00Z").unwrap().with_timezone(&chrono::Utc),
+        chrono::DateTime::<chrono::Utc>::default(),
+        chrono::DateTime::parse_from_rfc3339("2099-12-31T23:59:59Z").unwrap().with_timezone(&chrono::Utc),
+    ]);
+e2e_oracle_suite!(numeric, rust_decimal::Decimal, "proptest_e2e_numeric",
+    seeds = [
+        <rust_decimal::Decimal as std::str::FromStr>::from_str("-1000000000000").unwrap(),
+        rust_decimal::Decimal::ZERO,
+        <rust_decimal::Decimal as std::str::FromStr>::from_str("1000000000000").unwrap(),
+    ]);
+e2e_oracle_suite!(text, String, "proptest_e2e_text",
+    seeds = ["aard".to_string(), "frank".to_string(), "zzzz".to_string()]);

--- a/tests/sqlx/tests/encrypted_domain/property/e2e_oracle.rs
+++ b/tests/sqlx/tests/encrypted_domain/property/e2e_oracle.rs
@@ -28,7 +28,10 @@ async fn encrypt_rows<T>(pool_table: &str, values: &[T]) -> Result<Vec<Row<T>>>
 where
     T: ScalarType + EqlPlaintext + Clone,
 {
-    let config = column_config_for(&[IndexKind::Unique, IndexKind::Ore], <T as EqlPlaintext>::CAST)?;
+    let config = column_config_for(
+        &[IndexKind::Unique, IndexKind::Ore],
+        <T as EqlPlaintext>::CAST,
+    )?;
     let payloads = encrypt_store(pool_table, "payload", values, &config).await?;
     // Fail fast on a count mismatch: a silent `zip` truncation would weaken the
     // oracle (fewer pairs than intended) and hide an encrypt_store contract
@@ -52,12 +55,7 @@ where
 
 /// Drive proptest: each case is a corpus of integers. Generation is in-process;
 /// encryption + oracle is async on a current-thread runtime.
-fn run_e2e_property<T>(
-    table: &str,
-    cases: u32,
-    ordered: bool,
-    seeds: &[T],
-) -> Result<()>
+fn run_e2e_property<T>(table: &str, cases: u32, ordered: bool, seeds: &[T]) -> Result<()>
 where
     T: ScalarType + EqlPlaintext + Clone + 'static,
 {
@@ -130,26 +128,61 @@ macro_rules! e2e_oracle_suite {
     };
 }
 
-e2e_oracle_suite!(int4, i32, "proptest_e2e_int4", seeds = [i32::MIN, 0, i32::MAX]);
-e2e_oracle_suite!(int2, i16, "proptest_e2e_int2", seeds = [i16::MIN, 0, i16::MAX]);
-e2e_oracle_suite!(int8, i64, "proptest_e2e_int8", seeds = [i64::MIN, 0, i64::MAX]);
-e2e_oracle_suite!(date, chrono::NaiveDate, "proptest_e2e_date",
+e2e_oracle_suite!(
+    int4,
+    i32,
+    "proptest_e2e_int4",
+    seeds = [i32::MIN, 0, i32::MAX]
+);
+e2e_oracle_suite!(
+    int2,
+    i16,
+    "proptest_e2e_int2",
+    seeds = [i16::MIN, 0, i16::MAX]
+);
+e2e_oracle_suite!(
+    int8,
+    i64,
+    "proptest_e2e_int8",
+    seeds = [i64::MIN, 0, i64::MAX]
+);
+e2e_oracle_suite!(
+    date,
+    chrono::NaiveDate,
+    "proptest_e2e_date",
     seeds = [
         chrono::NaiveDate::from_ymd_opt(1900, 1, 1).unwrap(),
         chrono::NaiveDate::default(),
         chrono::NaiveDate::from_ymd_opt(2099, 12, 31).unwrap(),
-    ]);
-e2e_oracle_suite!(timestamptz, chrono::DateTime<chrono::Utc>, "proptest_e2e_timestamptz",
+    ]
+);
+e2e_oracle_suite!(
+    timestamptz,
+    chrono::DateTime<chrono::Utc>,
+    "proptest_e2e_timestamptz",
     seeds = [
-        chrono::DateTime::parse_from_rfc3339("1900-01-01T00:00:00Z").unwrap().with_timezone(&chrono::Utc),
+        chrono::DateTime::parse_from_rfc3339("1900-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
         chrono::DateTime::<chrono::Utc>::default(),
-        chrono::DateTime::parse_from_rfc3339("2099-12-31T23:59:59Z").unwrap().with_timezone(&chrono::Utc),
-    ]);
-e2e_oracle_suite!(numeric, rust_decimal::Decimal, "proptest_e2e_numeric",
+        chrono::DateTime::parse_from_rfc3339("2099-12-31T23:59:59Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc),
+    ]
+);
+e2e_oracle_suite!(
+    numeric,
+    rust_decimal::Decimal,
+    "proptest_e2e_numeric",
     seeds = [
         <rust_decimal::Decimal as std::str::FromStr>::from_str("-1000000000000").unwrap(),
         rust_decimal::Decimal::ZERO,
         <rust_decimal::Decimal as std::str::FromStr>::from_str("1000000000000").unwrap(),
-    ]);
-e2e_oracle_suite!(text, String, "proptest_e2e_text",
-    seeds = ["aard".to_string(), "frank".to_string(), "zzzz".to_string()]);
+    ]
+);
+e2e_oracle_suite!(
+    text,
+    String,
+    "proptest_e2e_text",
+    seeds = ["aard".to_string(), "frank".to_string(), "zzzz".to_string()]
+);

--- a/tests/sqlx/tests/encrypted_domain/property/fixture_oracle.rs
+++ b/tests/sqlx/tests/encrypted_domain/property/fixture_oracle.rs
@@ -203,15 +203,10 @@ async fn run_ord_oracle<T: ScalarType>(pool: PgPool, cases: u32) -> Result<()> {
     .await
 }
 
-#[sqlx::test]
-async fn prop_int4_eq_oracle_over_fixture(pool: PgPool) -> Result<()> {
-    run_eq_oracle::<i32>(pool, 48).await
-}
-
-#[sqlx::test]
-async fn prop_int4_ord_oracle_over_fixture(pool: PgPool) -> Result<()> {
-    run_ord_oracle::<i32>(pool, 48).await
-}
+/// All fixtured scalars run the same number of proptest cases — the fixture
+/// suite does no new encryption, so there is no reason for int4 to be
+/// privileged. Raise here (one place) if a regression ever needs more cases.
+const FIXTURE_ORACLE_CASES: u32 = 32;
 
 macro_rules! fixture_oracle_suite {
     ($modname:ident, $ty:ty, ordered) => {
@@ -219,11 +214,11 @@ macro_rules! fixture_oracle_suite {
             use super::*;
             #[sqlx::test]
             async fn eq_oracle(pool: PgPool) -> Result<()> {
-                run_eq_oracle::<$ty>(pool, 32).await
+                run_eq_oracle::<$ty>(pool, FIXTURE_ORACLE_CASES).await
             }
             #[sqlx::test]
             async fn ord_oracle(pool: PgPool) -> Result<()> {
-                run_ord_oracle::<$ty>(pool, 32).await
+                run_ord_oracle::<$ty>(pool, FIXTURE_ORACLE_CASES).await
             }
         }
     };
@@ -232,14 +227,16 @@ macro_rules! fixture_oracle_suite {
             use super::*;
             #[sqlx::test]
             async fn eq_oracle(pool: PgPool) -> Result<()> {
-                run_eq_oracle::<$ty>(pool, 32).await
+                run_eq_oracle::<$ty>(pool, FIXTURE_ORACLE_CASES).await
             }
         }
     };
 }
 
+fixture_oracle_suite!(int4, i32, ordered);
 fixture_oracle_suite!(int2, i16, ordered);
 fixture_oracle_suite!(int8, i64, ordered);
 fixture_oracle_suite!(date, chrono::NaiveDate, ordered);
+fixture_oracle_suite!(timestamptz, chrono::DateTime<chrono::Utc>, ordered);
+fixture_oracle_suite!(numeric, rust_decimal::Decimal, ordered);
 fixture_oracle_suite!(text, String, ordered);
-fixture_oracle_suite!(timestamptz, chrono::DateTime<chrono::Utc>, eq_only);

--- a/tests/sqlx/tests/encrypted_domain/property/fixture_oracle.rs
+++ b/tests/sqlx/tests/encrypted_domain/property/fixture_oracle.rs
@@ -60,6 +60,10 @@ fn embedded_fixture_sql<T: ScalarType>() -> &'static str {
                 "/fixtures/eql_v2_timestamptz.sql"
             ))
         }
+        "numeric" => include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/fixtures/eql_v2_numeric.sql"
+        )),
         other => panic!(
             "no embedded fixture for catalog token '{other}'; \
              add an include_str! arm in fixture_oracle.rs"

--- a/tests/sqlx/tests/encrypted_domain/signed.rs
+++ b/tests/sqlx/tests/encrypted_domain/signed.rs
@@ -1,5 +1,6 @@
-//! Sign-boundary coverage for **signed** scalars (`int`, `date`) — the
-//! `SignedScalar` delta on top of the uniform ordered matrix.
+//! Sign-boundary coverage for **signed** scalars (`int2`/`int4`/`int8`, `date`,
+//! `timestamptz`) — the `SignedScalar` delta on top of the uniform ordered
+//! matrix.
 //!
 //! ORE encrypts signed values as an offset from a numeric origin (`0` for
 //! integers, the epoch for dates). This suite asserts the ORE block ordering is
@@ -50,4 +51,19 @@ async fn int4_sign_boundary(pool: PgPool) -> anyhow::Result<()> {
 #[sqlx::test(fixtures(path = "../../fixtures", scripts("eql_v2_date")))]
 async fn date_sign_boundary(pool: PgPool) -> anyhow::Result<()> {
     sign_boundary_is_monotonic::<chrono::NaiveDate>(&pool).await
+}
+
+#[sqlx::test(fixtures(path = "../../fixtures", scripts("eql_v2_int2")))]
+async fn int2_sign_boundary(pool: PgPool) -> anyhow::Result<()> {
+    sign_boundary_is_monotonic::<i16>(&pool).await
+}
+
+#[sqlx::test(fixtures(path = "../../fixtures", scripts("eql_v2_int8")))]
+async fn int8_sign_boundary(pool: PgPool) -> anyhow::Result<()> {
+    sign_boundary_is_monotonic::<i64>(&pool).await
+}
+
+#[sqlx::test(fixtures(path = "../../fixtures", scripts("eql_v2_timestamptz")))]
+async fn timestamptz_sign_boundary(pool: PgPool) -> anyhow::Result<()> {
+    sign_boundary_is_monotonic::<chrono::DateTime<chrono::Utc>>(&pool).await
 }

--- a/tests/sqlx/tests/encrypted_domain/signed.rs
+++ b/tests/sqlx/tests/encrypted_domain/signed.rs
@@ -3,7 +3,7 @@
 //! matrix.
 //!
 //! ORE encrypts signed values as an offset from a numeric origin (`0` for
-//! integers, the epoch for dates). This suite asserts the ORE block ordering is
+//! integers, the epoch for `date`/`timestamptz`). This suite asserts the ORE block ordering is
 //! **monotonic across that origin**: a fixture below the origin orders before
 //! the origin, which orders before a fixture above it — through the encrypted
 //! `_ord` domain, with no decryption.


### PR DESCRIPTION
## Summary

Test-only refactor of the `eql_v3` scalar-domain test harness: shrink the hand-written per-type surface and grow the uniform, catalog-driven generated matrix so every live scalar type (`int2`/`int4`/`int8`/`date`/`timestamptz`/`numeric`/`text`) gets the same guarantees with no per-type hand-coding.

Implements `docs/plans/2026-06-18-v3-test-architecture-refactor-plan.md` (core Tasks 1–4 + optional 6A/6C/7; Tasks 5 and 6B deliberately skipped per the plan's own guidance).

## What changed

- **Native-jsonb blocker sweep → per-type matrix arm.** New `__scalar_matrix_native_jsonb_blocker_*` arm asserts the 10 native jsonb operators (`?`, `?|`, `?&`, `@?`, `@@`, `#>`, `#>>`, `-`, `#-`, `||`) raise the EQL blocker on every declared domain of every type. **Coverage 1 type → 7 types**; the int4-only hand-test is deleted (~78 lines). The operator symbol set is derived by exclusion from the codegen `OPERATORS` table (`is_native_jsonb_blocker`), pinned by tests on both the codegen side and the matrix side (incl. a runtime guard tying the arm's swept SQL to the pinned set).
- **Deleted 8 assertion-helper self-tests** in `family/support.rs` now subsumed by per-type matrix arms; kept the one minimal smoke test + two API-pin tests. Three-valued-logic `<>`-NULL caveat ported into the `supported_null` arm comment.
- **Catalog-driven placeholder-payload cast check** — was i32-only with a TODO; now sweeps every `CATALOG` row × declared domain.
- **Sign-boundary monotonicity** extended to `int2`/`int8`/`timestamptz` (was `int4`/`date`).
- **Derived boundary pivots (6A)** — `min_pivot`/`max_pivot` are now `OrderedScalar` trait defaults computed from `fixture_values()` (the supertrait bounds `Ord + Clone`), so a boundary pivot is a fixture row by construction and cannot drift. No impl overrides them; only `text`/`numeric` `mid_pivot` legitimately override `Default`. Behaviour-preserving (safety-net test passes before and after).
- **Count-distinct dispatch (6C)** — drops the macro `Storage` ident-match for a runtime `extractor_expr().is_none()` early-return, matching the precedent set by `aggregate_typecheck`.
- **Docs** — corrected stale "timestamptz is eq-only" references (it's been ordered since the N-block ORE comparator landed) and the derived-pivot design.

## Skipped (per plan guidance)

- **Task 5** (fold the v2 int4 fixture test): already largely subsumed by the matrix; the only non-redundant checks (`v='2'` envelope + plaintext oracle) are v2-specific with no v3 analogue — not worth the v2/v3 entanglement.
- **Task 6B** (de-dup caps tuple lists): the `@common` macro indirection is not clearly more readable than the honest duplication of two short tuple lists.

## Verification

- No-DB gates: `mise run test:matrix:inventory` (7 types reconciled), `mise run test:self_contained_v3` — green.
- Unit crates: `eql-codegen` (54), `eql-scalars` (58), `eql-tests-macros` (17), harness lib (100) — pass.
- DB-backed (real encrypted fixtures): all 7 scalar matrices, `native_jsonb_blockers` (29), `signed` (5), `family::support` (5), `count_distinct` (30), `jsonb_entry` (55) — pass.
- Generated-SQL grep confirms all 10 native ops render blockers on all 30 domains.
- Three matrix-inventory snapshots regenerated and committed.
- Four-lens code review (architecture / quality / coverage / comments): all PASS / PASS WITH NITS; nits folded in.

**No `CHANGELOG.md` entry or upgrade note** — test-only change.