### PR TITLE
test(v3): text-search direct-function coverage + bloom-vs-LIKE divergence lock-in

### DIFF
--- a/crates/eql-scalars/src/lib.rs
+++ b/crates/eql-scalars/src/lib.rs
@@ -476,7 +476,18 @@ pub const BOOL: ScalarSpec = ScalarSpec {
 /// median value, not `String::default()`.
 const TEXT_FIXTURES: &[Fixture] = fixtures!(text;
     "aard", "aardvark", "alice", "bob", "carol",
-    "dave", "erin", "frank", "mallory", "trent", "zzzz");
+    "dave", "erin", "frank", "mallory", "trent", "zzzz",
+    // Divergence pair (G3 4b): every contiguous 3-gram of NEEDLE (`abcabd` →
+    // {abc, bca, cab, abd}) is present in HAY (`qabcqbcaqcabqabd`), yet NEEDLE is
+    // NOT a contiguous substring of HAY (the `q` separators break the run). So
+    // bloom `@>` is true while `HAY LIKE '%NEEDLE%'` is false — the deterministic
+    // bloom-vs-LIKE divergence locked in by `bloom_matches_where_like_would_not`.
+    // Verified against the real cipherstash bf term sets (contiguous 3-grams,
+    // k=6 hashing): bf(NEEDLE) ⊆ bf(HAY). Both are 3-gram-disjoint from the
+    // `aard`/`zzzz` disjoint pair and sort interior to the min/mid/max pivots, so
+    // they perturb no eq/ord oracle. Keep them diverging if edited (the pure-Rust
+    // guard `divergence_pair_is_contiguity_diverging` in src/tests.rs enforces it).
+    "qabcqbcaqcabqabd", "abcabd");
 
 /// `text` — an ordered, non-integer, unbounded scalar. Adds a `_match` domain
 /// (the `Bloom` term) on top of the ordered shape. Public because the SQLx

--- a/crates/eql-scalars/src/tests.rs
+++ b/crates/eql-scalars/src/tests.rs
@@ -907,7 +907,10 @@ mod values_tests {
         const NEEDLE: &str = "abcabd";
 
         // Both must actually be present in the fixture corpus.
-        assert!(TEXT_VALUES.contains(&HAY), "TEXT_VALUES must contain HAY {HAY:?}");
+        assert!(
+            TEXT_VALUES.contains(&HAY),
+            "TEXT_VALUES must contain HAY {HAY:?}"
+        );
         assert!(
             TEXT_VALUES.contains(&NEEDLE),
             "TEXT_VALUES must contain NEEDLE {NEEDLE:?}"

--- a/crates/eql-scalars/src/tests.rs
+++ b/crates/eql-scalars/src/tests.rs
@@ -894,6 +894,50 @@ mod values_tests {
             .collect();
         assert_eq!(TEXT_VALUES.to_vec(), from_fixtures);
     }
+
+    #[test]
+    // The divergence pair (`HAY`/`NEEDLE`) added to TEXT_FIXTURES for G3 4b must
+    // stay diverging at the plaintext level: NEEDLE's contiguous 3-grams are all
+    // present in HAY's 3-gram set, yet NEEDLE is NOT a contiguous substring of HAY.
+    // That is exactly the bloom-`@>`-true / `LIKE`-false condition the SQLx test
+    // `bloom_matches_where_like_would_not` relies on. This guard is creds-free and
+    // fails fast if anyone edits the fixture words so they stop diverging.
+    fn divergence_pair_is_contiguity_diverging() {
+        const HAY: &str = "qabcqbcaqcabqabd";
+        const NEEDLE: &str = "abcabd";
+
+        // Both must actually be present in the fixture corpus.
+        assert!(TEXT_VALUES.contains(&HAY), "TEXT_VALUES must contain HAY {HAY:?}");
+        assert!(
+            TEXT_VALUES.contains(&NEEDLE),
+            "TEXT_VALUES must contain NEEDLE {NEEDLE:?}"
+        );
+
+        // Contiguous 3-grams of a string (the documented bloom tokenization:
+        // contiguous 3-grams, no padding).
+        fn trigrams(s: &str) -> std::collections::HashSet<&str> {
+            let b = s.as_bytes();
+            if b.len() < 3 {
+                // Sub-3 strings tokenize to the whole string; not used here but keep total.
+                return std::iter::once(s).collect();
+            }
+            (0..=b.len() - 3).map(|i| &s[i..i + 3]).collect()
+        }
+
+        let hay_grams = trigrams(HAY);
+        let needle_grams = trigrams(NEEDLE);
+
+        // (1) needle 3-grams ⊆ haystack 3-grams  → bloom `@>` would match.
+        assert!(
+            needle_grams.is_subset(&hay_grams),
+            "NEEDLE 3-grams {needle_grams:?} must be a subset of HAY 3-grams {hay_grams:?}"
+        );
+        // (2) needle is NOT a contiguous substring → `LIKE '%NEEDLE%'` would NOT match.
+        assert!(
+            !HAY.contains(NEEDLE),
+            "NEEDLE {NEEDLE:?} must NOT be a contiguous substring of HAY {HAY:?}"
+        );
+    }
 }
 
 mod invariant_tests {

--- a/tests/sqlx/tests/encrypted_domain/text/text_match.rs
+++ b/tests/sqlx/tests/encrypted_domain/text/text_match.rs
@@ -203,3 +203,107 @@ async fn contains_and_contained_by_are_commutative(pool: PgPool) -> anyhow::Resu
     );
     Ok(())
 }
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("eql_v2_text")))]
+async fn direct_contains_function_matches_operator(pool: PgPool) -> anyhow::Result<()> {
+    // Exercises `eql_v3.contains(a, b)` by NAME (not the `@>` operator), and pins
+    // that the function and the operator it backs agree. `aardvark` contains the
+    // substring needle `aard` (shared ngrams); the disjoint `zzzz` does not.
+    let hay = payload_for(&pool, "aardvark").await?;
+    let aard = payload_for(&pool, "aard").await?;
+    let zzzz = payload_for(&pool, "zzzz").await?;
+
+    let (fn_hit, op_hit, fn_miss): (bool, bool, bool) = sqlx::query_as(
+        "SELECT eql_v3.contains($1::jsonb::eql_v3.text_match, $2::jsonb::eql_v3.text_match),
+                ($1::jsonb::eql_v3.text_match) @> ($2::jsonb::eql_v3.text_match),
+                eql_v3.contains($1::jsonb::eql_v3.text_match, $3::jsonb::eql_v3.text_match)",
+    )
+    .bind(&hay)
+    .bind(&aard)
+    .bind(&zzzz)
+    .fetch_one(&pool)
+    .await?;
+
+    assert!(fn_hit, "eql_v3.contains('aardvark','aard') must be true");
+    assert_eq!(fn_hit, op_hit, "eql_v3.contains must agree with the @> operator");
+    assert!(!fn_miss, "eql_v3.contains('aardvark','zzzz') must be false (disjoint ngrams)");
+    Ok(())
+}
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("eql_v2_text")))]
+async fn direct_contained_by_function_matches_operator(pool: PgPool) -> anyhow::Result<()> {
+    // Exercises `eql_v3.contained_by(a, b)` by NAME (not the `<@` operator). `aard`
+    // is contained by `aardvark`; `zzzz` is not contained by `aard` (disjoint ngrams).
+    let aard = payload_for(&pool, "aard").await?;
+    let hay = payload_for(&pool, "aardvark").await?;
+    let zzzz = payload_for(&pool, "zzzz").await?;
+
+    let (fn_hit, op_hit, fn_miss): (bool, bool, bool) = sqlx::query_as(
+        "SELECT eql_v3.contained_by($1::jsonb::eql_v3.text_match, $2::jsonb::eql_v3.text_match),
+                ($1::jsonb::eql_v3.text_match) <@ ($2::jsonb::eql_v3.text_match),
+                eql_v3.contained_by($3::jsonb::eql_v3.text_match, $1::jsonb::eql_v3.text_match)",
+    )
+    .bind(&aard)
+    .bind(&hay)
+    .bind(&zzzz)
+    .fetch_one(&pool)
+    .await?;
+
+    assert!(fn_hit, "eql_v3.contained_by('aard','aardvark') must be true");
+    assert_eq!(fn_hit, op_hit, "eql_v3.contained_by must agree with the <@ operator");
+    assert!(!fn_miss, "eql_v3.contained_by('zzzz','aard') must be false (disjoint ngrams)");
+    Ok(())
+}
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("eql_v2_text")))]
+async fn mixed_jsonb_domain_overloads_agree(pool: PgPool) -> anyhow::Result<()> {
+    // The (text_match, jsonb), (jsonb, text_match) overloads cast the jsonb side
+    // internally; they must agree with the fully-cast (text_match, text_match) form.
+    // `aardvark` contains needle `aard` (shared ngrams).
+    let hay = payload_for(&pool, "aardvark").await?;
+    let aard = payload_for(&pool, "aard").await?;
+
+    // $1 = haystack, $2 = needle. Each column leaves one operand as bare jsonb so a
+    // DIFFERENT overload resolves; all must equal the all-domain baseline.
+    let row: (bool, bool, bool, bool, bool) = sqlx::query_as(
+        "SELECT
+           eql_v3.contains($1::jsonb::eql_v3.text_match, $2::jsonb::eql_v3.text_match), -- baseline (domain,domain)
+           eql_v3.contains($1::jsonb::eql_v3.text_match, $2::jsonb),                    -- (domain, jsonb)
+           eql_v3.contains($1::jsonb, $2::jsonb::eql_v3.text_match),                    -- (jsonb, domain)
+           eql_v3.contained_by($2::jsonb::eql_v3.text_match, $1::jsonb),                -- (domain, jsonb)
+           eql_v3.contained_by($2::jsonb, $1::jsonb::eql_v3.text_match)                 -- (jsonb, domain)
+        ",
+    )
+    .bind(&hay)
+    .bind(&aard)
+    .fetch_one(&pool)
+    .await?;
+
+    let (baseline, contains_dom_json, contains_json_dom, cby_dom_json, cby_json_dom) = row;
+    assert!(baseline, "baseline eql_v3.contains('aardvark','aard') must be true");
+    assert_eq!(contains_dom_json, baseline, "contains(domain, jsonb) must agree");
+    assert_eq!(contains_json_dom, baseline, "contains(jsonb, domain) must agree");
+    assert_eq!(cby_dom_json, baseline, "contained_by(domain, jsonb) must agree (commutator of contains)");
+    assert_eq!(cby_json_dom, baseline, "contained_by(jsonb, domain) must agree");
+    Ok(())
+}
+
+#[sqlx::test]
+async fn direct_functions_propagate_null(pool: PgPool) -> anyhow::Result<()> {
+    // STRICT: a NULL operand short-circuits the body and returns NULL, not false
+    // and not an error. Covers the by-name functions (the operator path is covered
+    // by text_smoke::match_null_propagates) including a mixed (domain, jsonb) form.
+    const BF: &str = r#"{"v":"2","i":{},"c":"x","bf":[1,2,3]}"#;
+
+    // $1 NULL, $2 a real payload — and the reverse — across both functions, both
+    // operand positions, and a mixed jsonb overload.
+    for sql in [
+        "SELECT eql_v3.contains($1::jsonb::eql_v3.text_match, $2::jsonb::eql_v3.text_match)",
+        "SELECT eql_v3.contained_by($1::jsonb::eql_v3.text_match, $2::jsonb::eql_v3.text_match)",
+        "SELECT eql_v3.contains($1::jsonb::eql_v3.text_match, $2::jsonb)", // mixed (domain, jsonb)
+    ] {
+        eql_tests::assert_null(&pool, sql, &[None, Some(BF)]).await?;
+        eql_tests::assert_null(&pool, sql, &[Some(BF), None]).await?;
+    }
+    Ok(())
+}

--- a/tests/sqlx/tests/encrypted_domain/text/text_match.rs
+++ b/tests/sqlx/tests/encrypted_domain/text/text_match.rs
@@ -225,8 +225,14 @@ async fn direct_contains_function_matches_operator(pool: PgPool) -> anyhow::Resu
     .await?;
 
     assert!(fn_hit, "eql_v3.contains('aardvark','aard') must be true");
-    assert_eq!(fn_hit, op_hit, "eql_v3.contains must agree with the @> operator");
-    assert!(!fn_miss, "eql_v3.contains('aardvark','zzzz') must be false (disjoint ngrams)");
+    assert_eq!(
+        fn_hit, op_hit,
+        "eql_v3.contains must agree with the @> operator"
+    );
+    assert!(
+        !fn_miss,
+        "eql_v3.contains('aardvark','zzzz') must be false (disjoint ngrams)"
+    );
     Ok(())
 }
 
@@ -249,9 +255,18 @@ async fn direct_contained_by_function_matches_operator(pool: PgPool) -> anyhow::
     .fetch_one(&pool)
     .await?;
 
-    assert!(fn_hit, "eql_v3.contained_by('aard','aardvark') must be true");
-    assert_eq!(fn_hit, op_hit, "eql_v3.contained_by must agree with the <@ operator");
-    assert!(!fn_miss, "eql_v3.contained_by('zzzz','aard') must be false (disjoint ngrams)");
+    assert!(
+        fn_hit,
+        "eql_v3.contained_by('aard','aardvark') must be true"
+    );
+    assert_eq!(
+        fn_hit, op_hit,
+        "eql_v3.contained_by must agree with the <@ operator"
+    );
+    assert!(
+        !fn_miss,
+        "eql_v3.contained_by('zzzz','aard') must be false (disjoint ngrams)"
+    );
     Ok(())
 }
 
@@ -280,11 +295,26 @@ async fn mixed_jsonb_domain_overloads_agree(pool: PgPool) -> anyhow::Result<()> 
     .await?;
 
     let (baseline, contains_dom_json, contains_json_dom, cby_dom_json, cby_json_dom) = row;
-    assert!(baseline, "baseline eql_v3.contains('aardvark','aard') must be true");
-    assert_eq!(contains_dom_json, baseline, "contains(domain, jsonb) must agree");
-    assert_eq!(contains_json_dom, baseline, "contains(jsonb, domain) must agree");
-    assert_eq!(cby_dom_json, baseline, "contained_by(domain, jsonb) must agree (commutator of contains)");
-    assert_eq!(cby_json_dom, baseline, "contained_by(jsonb, domain) must agree");
+    assert!(
+        baseline,
+        "baseline eql_v3.contains('aardvark','aard') must be true"
+    );
+    assert_eq!(
+        contains_dom_json, baseline,
+        "contains(domain, jsonb) must agree"
+    );
+    assert_eq!(
+        contains_json_dom, baseline,
+        "contains(jsonb, domain) must agree"
+    );
+    assert_eq!(
+        cby_dom_json, baseline,
+        "contained_by(domain, jsonb) must agree (commutator of contains)"
+    );
+    assert_eq!(
+        cby_json_dom, baseline,
+        "contained_by(jsonb, domain) must agree"
+    );
     Ok(())
 }
 
@@ -315,7 +345,7 @@ async fn bloom_matches_where_like_would_not(pool: PgPool) -> anyhow::Result<()> 
     // matches — but the needle is NOT a contiguous substring, so `LIKE '%needle%'`
     // would NOT match. This false-positive / order-independence is the deterministic
     // divergence from LIKE (bloom has no false negatives, so the reverse can't happen).
-    // The pair is engineered for exactly this property in TEXT_FIXTURES; see the plan.
+    // The pair is engineered for exactly this property in TEXT_FIXTURES.
     let hay = payload_for(&pool, "qabcqbcaqcabqabd").await?;
     let needle = payload_for(&pool, "abcabd").await?;
 
@@ -341,12 +371,11 @@ async fn bloom_matches_where_like_would_not(pool: PgPool) -> anyhow::Result<()> 
     //    domain operator. This localizes a future tokenizer change (e.g. honoring
     //    `include_original`, a different ngram width) to a precise "bf arrays no
     //    longer a subset" failure instead of an opaque `@>`-returned-false.
-    let bf_subset: bool =
-        sqlx::query_scalar("SELECT ($1::jsonb -> 'bf') @> ($2::jsonb -> 'bf')")
-            .bind(&hay)
-            .bind(&needle)
-            .fetch_one(&pool)
-            .await?;
+    let bf_subset: bool = sqlx::query_scalar("SELECT ($1::jsonb -> 'bf') @> ($2::jsonb -> 'bf')")
+        .bind(&hay)
+        .bind(&needle)
+        .fetch_one(&pool)
+        .await?;
     assert!(
         bf_subset,
         "needle's raw bf terms must be a subset of the haystack's (native jsonb containment)"
@@ -355,12 +384,11 @@ async fn bloom_matches_where_like_would_not(pool: PgPool) -> anyhow::Result<()> 
     // 3. LIKE would NOT match the same plaintext pair — pin the divergence directly on
     //    the cleartext so the assertion documents the contract independently of any
     //    encrypted representation.
-    let like_hit: bool =
-        sqlx::query_scalar("SELECT $1 LIKE '%' || $2 || '%'")
-            .bind("qabcqbcaqcabqabd")
-            .bind("abcabd")
-            .fetch_one(&pool)
-            .await?;
+    let like_hit: bool = sqlx::query_scalar("SELECT $1 LIKE '%' || $2 || '%'")
+        .bind("qabcqbcaqcabqabd")
+        .bind("abcabd")
+        .fetch_one(&pool)
+        .await?;
     assert!(
         !like_hit,
         "LIKE must NOT match: the needle is not a contiguous substring of the haystack"

--- a/tests/sqlx/tests/encrypted_domain/text/text_match.rs
+++ b/tests/sqlx/tests/encrypted_domain/text/text_match.rs
@@ -307,3 +307,64 @@ async fn direct_functions_propagate_null(pool: PgPool) -> anyhow::Result<()> {
     }
     Ok(())
 }
+
+#[sqlx::test(fixtures(path = "../../../fixtures", scripts("eql_v2_text")))]
+async fn bloom_matches_where_like_would_not(pool: PgPool) -> anyhow::Result<()> {
+    // Locks in WHY v3 dropped `LIKE` for bloom containment: the two are not the same
+    // relation. The needle's ngrams are all present in the haystack, so bloom `@>`
+    // matches — but the needle is NOT a contiguous substring, so `LIKE '%needle%'`
+    // would NOT match. This false-positive / order-independence is the deterministic
+    // divergence from LIKE (bloom has no false negatives, so the reverse can't happen).
+    // The pair is engineered for exactly this property in TEXT_FIXTURES; see the plan.
+    let hay = payload_for(&pool, "qabcqbcaqcabqabd").await?;
+    let needle = payload_for(&pool, "abcabd").await?;
+
+    // 1. bloom DOES match.
+    let bloom_hit: bool = sqlx::query_scalar(
+        "SELECT ($1::jsonb::eql_v3.text_match) @> ($2::jsonb::eql_v3.text_match)",
+    )
+    .bind(&hay)
+    .bind(&needle)
+    .fetch_one(&pool)
+    .await?;
+    assert!(
+        bloom_hit,
+        "bloom @> must match: needle ngrams are a subset of the haystack's"
+    );
+
+    // 2. Pin the *structural* reason `@>` matched, independently of the domain
+    //    operator. The domain `@>` is `match_term(a) @> match_term(b)`, i.e.
+    //    smallint[] array containment on the extracted bloom terms — so asserting it
+    //    again would just re-run the operator under test (circular). Instead assert
+    //    needle-bf ⊆ haystack-bf directly on the raw stored `bf` arrays via NATIVE
+    //    jsonb containment, which routes through neither `eql_v3.match_term` nor the
+    //    domain operator. This localizes a future tokenizer change (e.g. honoring
+    //    `include_original`, a different ngram width) to a precise "bf arrays no
+    //    longer a subset" failure instead of an opaque `@>`-returned-false.
+    let bf_subset: bool =
+        sqlx::query_scalar("SELECT ($1::jsonb -> 'bf') @> ($2::jsonb -> 'bf')")
+            .bind(&hay)
+            .bind(&needle)
+            .fetch_one(&pool)
+            .await?;
+    assert!(
+        bf_subset,
+        "needle's raw bf terms must be a subset of the haystack's (native jsonb containment)"
+    );
+
+    // 3. LIKE would NOT match the same plaintext pair — pin the divergence directly on
+    //    the cleartext so the assertion documents the contract independently of any
+    //    encrypted representation.
+    let like_hit: bool =
+        sqlx::query_scalar("SELECT $1 LIKE '%' || $2 || '%'")
+            .bind("qabcqbcaqcabqabd")
+            .bind("abcabd")
+            .fetch_one(&pool)
+            .await?;
+    assert!(
+        !like_hit,
+        "LIKE must NOT match: the needle is not a contiguous substring of the haystack"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes the §4.4 (G3) text-match test sub-gaps for the `eql_v3` text-search surface. Two logical commits, both test-only (no SQL surface changes):

- **G3 4a — direct-function-by-name coverage** (`tests/.../text/text_match.rs`): exercises `eql_v3.contains` / `eql_v3.contained_by` *by name* (not just the `@>` / `<@` operators), pins them in agreement with the operators, covers the mixed `(domain, jsonb)` / `(jsonb, domain)` overloads callers actually hit, and pins the `STRICT` NULL-propagation contract of the functions (the existing `text_smoke::match_null_propagates` only covers the operator path).
- **G3 4b — bloom-vs-LIKE semantic divergence lock-in**: an engineered fixture pair (`HAY="qabcqbcaqcabqabd"`, `NEEDLE="abcabd"`) where NEEDLE's ngrams are all ⊆ HAY's ngram set, yet NEEDLE is not a contiguous substring of HAY — so bloom `@>` matches while `LIKE '%needle%'` does not. Backed by a creds-free catalog `#[test]` (`divergence_pair_is_contiguity_diverging`) pinning the plaintext invariant, and a real-ciphertext SQLx test.

## Divergence test: independent bf-subset assertion

The SQLx divergence test now also asserts `needle-bf ⊆ haystack-bf` **directly on the stored `bf` arrays via native jsonb containment** — independent of the domain `@>` operator (which is `match_term(a) @> match_term(b)`, i.e. `smallint[]` array containment) and the `match_term` extractor. Previously the subset relation was only inferred from the same `@>` the test was validating (circular); the direct check localizes a future tokenizer change (e.g. honoring `include_original`, a different ngram width) to a precise "bf arrays no longer a subset" failure rather than an opaque `@>`-returned-false.

## Notes

- No `eql_v3` SQL surface changes. The only catalog change is two new `TEXT_FIXTURES` plaintexts (the engineered divergence pair); matrix snapshots are unaffected (adding fixture *values* adds no `scalars::<T>::*` test names).
- An earlier `docs/upgrading/v2.4.md` upgrade-note commit was dropped from this branch — version-numbered v2.x upgrade docs are the wrong model for the `eql_v3` surface.

## Test plan

- `cargo test -p eql-scalars` (creds-free) — catalog invariants incl. `divergence_pair_is_contiguity_diverging`.
- `cargo test --features proptest-e2e bloom_matches_where_like_would_not` — **passes** against real ciphertext (verified locally: `1 passed`).
- Full SQLx suite (`mise run test`) runs against live PG + CipherStash creds per repo convention.