### PR TITLE
ci(release): publish eql-bindings to crates.io via release-plz

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -20,12 +20,31 @@ actually runs).
 | **test-eql.yml** | `pull_request`, `merge_group`, `workflow_dispatch` | Full test/lint/validate matrix; the one required check | **Yes** — `ci-required` |
 | **release-eql.yml** | `release: published`, `pull_request` (paths), `workflow_dispatch` | Build release SQL + docs; PR runs everything **but** the publish step | No |
 | **release-postgres-eql-image.yml** | `release: published`, `workflow_dispatch` | Build & push the Postgres+EQL Docker image to GHCR | No |
+| **release-plz.yml** | `push: main`, `workflow_dispatch` | Publish the `eql-bindings` crate to crates.io (Trusted Publishing) + open the release PR | No |
 | **bench-eql.yml** | `push: main` (paths), `schedule` 02:00 UTC daily, `workflow_dispatch` | `test:bench` (bench cargo feature). **Never runs on PRs** | No |
 | **macro-expand-eql.yml** | `schedule` 03:00 UTC daily, `workflow_dispatch` | Regenerate the int4 `cargo expand` matrix snapshot; needs pinned nightly | **No — explicitly non-blocking** |
 | **rebuild-docs.yml** | `push: tags` | Fire a docs-site rebuild webhook | N/A |
 
 Only **test-eql.yml** gates merges. Bench regressions and stale `cargo expand`
 snapshots surface on the nightly schedule, not on the PR that caused them.
+
+### Two release tag families
+
+There are two independent release flows keyed on distinct git tags:
+
+- **`eql-<semver>`** (e.g. `eql-3.0.0`) — the EQL **SQL surface** release, cut
+  manually as a GitHub Release. Drives `release-eql.yml`,
+  `release-postgres-eql-image.yml`, and `rebuild-docs.yml`.
+- **`eql-bindings-v<semver>`** (e.g. `eql-bindings-v0.1.0`) — the **`eql-bindings`
+  Rust crate** release, cut automatically by `release-plz.yml` when its release
+  PR merges. Publishes to crates.io only.
+
+The three SQL-surface workflows explicitly **exclude** `eql-bindings-*` tags
+(`!startsWith(...'eql-bindings')` guards; a `!eql-bindings-*` filter in
+`rebuild-docs.yml`) so a crate release never triggers an SQL build, Docker
+image, or docs-site rebuild. `eql-bindings` is tested on every PR by the
+`rust-crates` job (`mise run test:crates` plus a `cargo publish --dry-run`
+packaging gate); every other workspace crate is `publish = false`.
 
 ---
 

--- a/.github/workflows/rebuild-docs.yml
+++ b/.github/workflows/rebuild-docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'eql-*'
+      # Exclude the eql-bindings crate tags (eql-bindings-v*) cut by release-plz
+      # — a Rust-crate release must not fire the docs-site rebuild webhook.
+      - '!eql-bindings-*'
 
 jobs:
   trigger-docs-rebuild:

--- a/.github/workflows/release-eql.yml
+++ b/.github/workflows/release-eql.yml
@@ -28,8 +28,11 @@ jobs:
     runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Verify CHANGELOG entry
     # Only real (non-prerelease) eql-* releases. Pre-releases keep their
-    # entries under [Unreleased] until the final release is cut.
-    if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'eql') && github.event.release.prerelease == false }}
+    # entries under [Unreleased] until the final release is cut. The
+    # `!startsWith(...'eql-bindings')` guard excludes the eql-bindings crate
+    # tags (eql-bindings-v*) cut by release-plz — those are Rust-crate releases,
+    # not SQL-surface releases.
+    if: ${{ github.event_name == 'release' && contains(github.event.release.tag_name, 'eql') && !startsWith(github.event.release.tag_name, 'eql-bindings') && github.event.release.prerelease == false }}
     timeout-minutes: 5
 
     steps:
@@ -50,7 +53,9 @@ jobs:
   build-and-publish:
     runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Build EQL
-    if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, 'eql') }}
+    # `!startsWith(...'eql-bindings')` excludes the eql-bindings crate tags
+    # (eql-bindings-v*) cut by release-plz, which are not SQL-surface releases.
+    if: ${{ github.event_name != 'release' || (contains(github.event.release.tag_name, 'eql') && !startsWith(github.event.release.tag_name, 'eql-bindings')) }}
     timeout-minutes: 5
 
     steps:
@@ -100,7 +105,9 @@ jobs:
   publish-docs:
     runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Build and Publish Documentation
-    if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, 'eql') }}
+    # `!startsWith(...'eql-bindings')` excludes the eql-bindings crate tags
+    # (eql-bindings-v*) cut by release-plz, which are not SQL-surface releases.
+    if: ${{ github.event_name != 'release' || (contains(github.event.release.tag_name, 'eql') && !startsWith(github.event.release.tag_name, 'eql-bindings')) }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,24 +1,34 @@
 name: "Release eql-bindings (crates.io)"
 
-# Publishes the `eql-bindings` crate to crates.io via release-plz.
+# Publishes the `eql-bindings` crate to crates.io via release-plz. Mirrors the
+# canonical cipherstash-suite release-plz setup (crates.io Trusted Publishing
+# via OIDC — no long-lived token; GPG-signed release commits/tags; `release`
+# before `release-pr`) and keeps EQL's own infra conventions (blacksmith runner,
+# mise toolchain).
 #
-# Two jobs, both on push to main (i.e. after a PR merges through the queue):
-#   * release      — publishes any crate version whose tag does not yet exist,
-#                     creates the git tag + GitHub Release. Uses crates.io
-#                     Trusted Publishing (OIDC) — NO long-lived token.
-#   * release-pr   — opens/updates the "release" PR that bumps the version and
-#                     updates crates/eql-bindings/CHANGELOG.md from the commits.
+# Flow (see also cipherstash-suite RELEASING.md):
+#   1. Push to main -> `release-pr` opens/updates a release PR (version bump +
+#      crates/eql-bindings/CHANGELOG.md from conventional commits).
+#   2. Merge that PR -> `release` publishes to crates.io, tags, and cuts a
+#      GitHub Release.
+# `release-pr` runs AFTER `release` (needs: release): if it ran first it would
+# see the just-merged `chore: release` commit as unreleased and open a recursive
+# release PR. (cipherstash-suite commit 02a989405.)
 #
-# One-time crates.io setup (Trusted Publishing): on crates.io, under the
-# eql-bindings crate's Settings -> Trusted Publishing, add a GitHub publisher:
-#   owner=cipherstash  repo=encrypt-query-language  workflow=release-plz.yml
-# For a brand-new crate name, register the trusted publisher before the first
-# publish (crates.io supports pre-registering a publisher for an unclaimed name).
+# One-time crates.io setup (Trusted Publishing): on the eql-bindings crate's
+# Settings -> Trusted Publishing, add a GitHub publisher with
+#   Repository: cipherstash/encrypt-query-language   Workflow: release-plz.yml
+# For a brand-new crate name, register the publisher before the first publish.
 #
-# NB: PRs opened by the default GITHUB_TOKEN do not trigger other workflows, so
-# the release PR would not get CI. To run CI on the release PR, add a
-# fine-grained PAT or GitHub App token as the `RELEASE_PLZ_TOKEN` secret; it is
-# picked up automatically below (falling back to GITHUB_TOKEN when unset).
+# Secrets: GPG_PRIVATE_KEY (release-commit/tag signing key). crates.io auth is
+# OIDC (id-token: write), so NO CARGO_REGISTRY_TOKEN. The GitHub PR/tag ops use
+# the default GITHUB_TOKEN; enable "Allow GitHub Actions to create and approve
+# pull requests" in repo settings so the release PR can be opened.
+
+permissions:
+  pull-requests: write
+  contents: write
+  id-token: write # crates.io Trusted Publishing (OIDC)
 
 on:
   push:
@@ -34,27 +44,30 @@ defaults:
   run:
     shell: bash {0}
 
-# Never run two release-plz invocations concurrently — a second run could race
-# the tag/publish of the first.
+# Static group: push-to-main and workflow_dispatch share it so two release-plz
+# invocations never race a tag/publish. Never cancel — a cancelled release could
+# leave a half-published state.
 concurrency:
-  group: release-plz-${{ github.ref }}
+  group: release-plz
   cancel-in-progress: false
 
 jobs:
-  # Publish crates whose version tag doesn't exist yet + cut the GitHub Release.
   release:
-    name: "Publish to crates.io"
+    name: "Release"
     runs-on: blacksmith-16vcpu-ubuntu-2204
-    # Do not run on forks.
-    if: ${{ github.repository == 'cipherstash/encrypt-query-language' }}
-    permissions:
-      contents: write # push tags + create GitHub Releases
-      id-token: write # crates.io Trusted Publishing (OIDC)
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+
+      # Sign release-plz's commits and tags with the shared release key.
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
 
       - uses: jdx/mise-action@v3
         with:
@@ -62,32 +75,29 @@ jobs:
           install: true
           cache: true
 
-      # Mint a short-lived crates.io token from the GitHub OIDC identity. No
-      # secret is stored in the repo; the token is scoped to this run.
-      - uses: rust-lang/crates-io-auth-action@v1
-        id: auth
-
       - name: Run release-plz release
         uses: release-plz/action@v0.5
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Open/update the release PR (version bump + changelog).
   release-pr:
-    name: "Open release PR"
+    name: "Release PR"
     runs-on: blacksmith-16vcpu-ubuntu-2204
-    if: ${{ github.repository == 'cipherstash/encrypt-query-language' }}
-    permissions:
-      contents: write # push the release branch
-      pull-requests: write # open/update the release PR
+    needs: release
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
 
       - uses: jdx/mise-action@v3
         with:
@@ -100,4 +110,4 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,103 @@
+name: "Release eql-bindings (crates.io)"
+
+# Publishes the `eql-bindings` crate to crates.io via release-plz.
+#
+# Two jobs, both on push to main (i.e. after a PR merges through the queue):
+#   * release      — publishes any crate version whose tag does not yet exist,
+#                     creates the git tag + GitHub Release. Uses crates.io
+#                     Trusted Publishing (OIDC) — NO long-lived token.
+#   * release-pr   — opens/updates the "release" PR that bumps the version and
+#                     updates crates/eql-bindings/CHANGELOG.md from the commits.
+#
+# One-time crates.io setup (Trusted Publishing): on crates.io, under the
+# eql-bindings crate's Settings -> Trusted Publishing, add a GitHub publisher:
+#   owner=cipherstash  repo=encrypt-query-language  workflow=release-plz.yml
+# For a brand-new crate name, register the trusted publisher before the first
+# publish (crates.io supports pre-registering a publisher for an unclaimed name).
+#
+# NB: PRs opened by the default GITHUB_TOKEN do not trigger other workflows, so
+# the release PR would not get CI. To run CI on the release PR, add a
+# fine-grained PAT or GitHub App token as the `RELEASE_PLZ_TOKEN` secret; it is
+# picked up automatically below (falling back to GITHUB_TOKEN when unset).
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  MISE_VERBOSE: "1"
+
+defaults:
+  run:
+    shell: bash {0}
+
+# Never run two release-plz invocations concurrently — a second run could race
+# the tag/publish of the first.
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Publish crates whose version tag doesn't exist yet + cut the GitHub Release.
+  release:
+    name: "Publish to crates.io"
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    # Do not run on forks.
+    if: ${{ github.repository == 'cipherstash/encrypt-query-language' }}
+    permissions:
+      contents: write # push tags + create GitHub Releases
+      id-token: write # crates.io Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      # Mint a short-lived crates.io token from the GitHub OIDC identity. No
+      # secret is stored in the repo; the token is scoped to this run.
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  # Open/update the release PR (version bump + changelog).
+  release-pr:
+    name: "Open release PR"
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    if: ${{ github.repository == 'cipherstash/encrypt-query-language' }}
+    permissions:
+      contents: write # push the release branch
+      pull-requests: write # open/update the release PR
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      - name: Run release-plz release-pr
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-postgres-eql-image.yml
+++ b/.github/workflows/release-postgres-eql-image.yml
@@ -33,7 +33,10 @@ jobs:
   build-sql:
     runs-on: blacksmith-16vcpu-ubuntu-2204
     name: Build EQL SQL
-    if: ${{ github.event_name != 'release' || contains(github.event.release.tag_name, 'eql') }}
+    # `!startsWith(...'eql-bindings')` excludes the eql-bindings crate tags
+    # (eql-bindings-v*) cut by release-plz — a Rust-crate release must not build
+    # a Postgres+EQL image. Downstream jobs `needs: build-sql`, so they skip too.
+    if: ${{ github.event_name != 'release' || (contains(github.event.release.tag_name, 'eql') && !startsWith(github.event.release.tag_name, 'eql-bindings')) }}
     timeout-minutes: 5
     outputs:
       # Used for image tags, e.g. "2.1.8" -> ghcr.io/.../postgres-eql:17-2.1.8

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -344,6 +344,16 @@ jobs:
         run: |
           mise run types:check
 
+      # Publish gate for eql-bindings (the one crate we ship to crates.io via
+      # release-plz). `--dry-run` packages + compiles the crate exactly as
+      # crates.io would, catching publish-blockers — missing `license`/metadata,
+      # a real path dependency without a version — on the PR rather than at
+      # release time. No token needed. `--allow-dirty` tolerates any files the
+      # preceding regenerate-and-diff steps leave in the working tree.
+      - name: Verify eql-bindings packages cleanly for crates.io
+        run: |
+          cargo publish -p eql-bindings --dry-run --allow-dirty
+
   codegen:
     name: "Encrypted-domain codegen"
     needs: [changes]

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,34 @@
+# git-cliff changelog template for release-plz (mirrors cipherstash-suite).
+# Drives the per-crate CHANGELOG.md that release-plz generates for eql-bindings.
+# The repository-root CHANGELOG.md is the hand-maintained EQL SQL-surface
+# changelog and is NOT touched by release-plz.
+[changelog]
+header = ""
+body = """
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | trim }}\
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+# `review(...)` commits are PR-feedback housekeeping (addressing reviewer
+# comments). They don't represent user-facing changes — the underlying
+# feat/fix/refactor commits already capture those — so skip them rather than
+# letting the raw `review` type become a stray "### Review" changelog section.
+commit_parsers = [
+    { message = "^review", skip = true },
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI" },
+]

--- a/crates/eql-bindings/CHANGELOG.md
+++ b/crates/eql-bindings/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to the `eql-bindings` crate are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This file is maintained by [release-plz](https://release-plz.dev/) — entries are
+generated from commit history when the release PR is cut. It is separate from
+the repository-root `CHANGELOG.md`, which tracks the EQL SQL surface.
+
+## [Unreleased]

--- a/crates/eql-bindings/CHANGELOG.md
+++ b/crates/eql-bindings/CHANGELOG.md
@@ -1,11 +1,6 @@
 # Changelog
 
-All notable changes to the `eql-bindings` crate are documented here.
+All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this crate adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-This file is maintained by [release-plz](https://release-plz.dev/) — entries are
-generated from commit history when the release PR is cut. It is separate from
-the repository-root `CHANGELOG.md`, which tracks the EQL SQL surface.
-
-## [Unreleased]
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/eql-bindings/Cargo.toml
+++ b/crates/eql-bindings/Cargo.toml
@@ -3,6 +3,14 @@ name = "eql-bindings"
 version = "0.1.0"
 edition = "2021"
 description = "Canonical wire types for EQL payloads — single source of truth for Rust, TypeScript (ts-rs), and JSON Schema (schemars)."
+# crates.io metadata. `license` is REQUIRED by crates.io — publish fails without
+# it. The rest drive discoverability and the docs.rs / crates.io sidebar links.
+license = "MIT"
+repository = "https://github.com/cipherstash/encrypt-query-language"
+homepage = "https://github.com/cipherstash/encrypt-query-language"
+readme = "README.md"
+keywords = ["encryption", "postgres", "eql", "cipherstash", "searchable"]
+categories = ["cryptography", "database"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/eql-domains/Cargo.toml
+++ b/crates/eql-domains/Cargo.toml
@@ -3,6 +3,9 @@ name = "eql-domains"
 version = "0.1.0"
 edition = "2021"
 description = "Scalar/term catalog for EQL encrypted-domain codegen (std-only, no deps)."
+# Internal build/codegen crate — not published to crates.io. release-plz skips
+# `publish = false` packages, so only eql-bindings is ever released.
+publish = false
 
 # INTENTIONALLY no dependencies. This crate must stay std-only so the future
 # generator (eql-codegen) compiles in ~1-2s and never drags serde/toml onto the

--- a/crates/eql-tests-macros/Cargo.toml
+++ b/crates/eql-tests-macros/Cargo.toml
@@ -3,6 +3,9 @@ name = "eql-tests-macros"
 version = "0.1.0"
 edition = "2021"
 description = "Proc-macros that expand a single scalar-harness list into the per-type SQLx-matrix wiring (ScalarType impls, fixture modules, matrix suites, fixture dispatch)."
+# Internal test-support crate — not published to crates.io. release-plz skips
+# `publish = false` packages, so only eql-bindings is ever released.
+publish = false
 
 [lib]
 proc-macro = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,30 @@
+# release-plz configuration.
+#
+# Scope: this repository's primary artefact is the EQL SQL surface, released
+# manually via `eql-<semver>` git tags (see `.github/workflows/release-eql.yml`
+# and the "Cutting a release" section of CLAUDE.md). release-plz is scoped
+# NARROWLY to publishing the one Rust crate we ship to crates.io:
+# `eql-bindings`. Every other workspace member is `publish = false` in its
+# Cargo.toml, and release-plz automatically skips `publish = false` packages —
+# so there is no per-package `release = false` to maintain here.
+#
+# The crate is tagged `eql-bindings-v<semver>` (release-plz's default workspace
+# tag). That tag deliberately does NOT match the EQL SQL-release automation:
+# the `eql`-keyed workflows (release-eql, release-postgres-eql-image,
+# rebuild-docs) now exclude `eql-bindings-*` so a crate release never triggers
+# an SQL build, Docker image, or docs-site rebuild.
+
+[workspace]
+# Keep a per-crate changelog (crates/eql-bindings/CHANGELOG.md) — the repo-root
+# CHANGELOG.md is the SQL surface's changelog and must stay untouched.
+changelog_update = true
+# Create a GitHub Release for each published crate version.
+git_release_enable = true
+# Open the release PR against main with a clear label.
+pr_labels = ["release", "eql-bindings"]
+
+[[package]]
+name = "eql-bindings"
+# Explicit even though it is the only publishable crate: documents intent and
+# guards against a future crate accidentally being picked up.
+release = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,30 +1,23 @@
-# release-plz configuration.
+# release-plz configuration. Mirrors the canonical cipherstash-suite setup.
 #
 # Scope: this repository's primary artefact is the EQL SQL surface, released
 # manually via `eql-<semver>` git tags (see `.github/workflows/release-eql.yml`
-# and the "Cutting a release" section of CLAUDE.md). release-plz is scoped
-# NARROWLY to publishing the one Rust crate we ship to crates.io:
-# `eql-bindings`. Every other workspace member is `publish = false` in its
-# Cargo.toml, and release-plz automatically skips `publish = false` packages —
-# so there is no per-package `release = false` to maintain here.
+# and the "Cutting a release" section of CLAUDE.md). release-plz is scoped to
+# the one Rust crate we ship to crates.io: `eql-bindings`. Every other workspace
+# member is `publish = false` in its Cargo.toml, so release-plz skips it
+# automatically (same convention as cipherstash-suite) — no per-package config.
 #
 # The crate is tagged `eql-bindings-v<semver>` (release-plz's default workspace
-# tag). That tag deliberately does NOT match the EQL SQL-release automation:
-# the `eql`-keyed workflows (release-eql, release-postgres-eql-image,
-# rebuild-docs) now exclude `eql-bindings-*` so a crate release never triggers
-# an SQL build, Docker image, or docs-site rebuild.
+# tag). That tag deliberately does NOT match the EQL SQL-release automation: the
+# `eql`-keyed workflows (release-eql, release-postgres-eql-image, rebuild-docs)
+# exclude `eql-bindings-*`, so a crate release never triggers an SQL build,
+# Docker image, or docs-site rebuild.
 
 [workspace]
-# Keep a per-crate changelog (crates/eql-bindings/CHANGELOG.md) — the repo-root
-# CHANGELOG.md is the SQL surface's changelog and must stay untouched.
-changelog_update = true
-# Create a GitHub Release for each published crate version.
+changelog_config = "cliff.toml"
+git_tag_enable = true
 git_release_enable = true
-# Open the release PR against main with a clear label.
-pr_labels = ["release", "eql-bindings"]
-
-[[package]]
-name = "eql-bindings"
-# Explicit even though it is the only publishable crate: documents intent and
-# guards against a future crate accidentally being picked up.
-release = true
+publish = true
+# semver_check is noisy for a pre-1.0 crate and duplicated by the PR review;
+# disabled to match cipherstash-suite.
+semver_check = false

--- a/tests/sqlx/Cargo.toml
+++ b/tests/sqlx/Cargo.toml
@@ -2,6 +2,9 @@
 name = "eql_tests"
 version = "0.1.0"
 edition = "2021"
+# Integration-test crate — not published to crates.io. release-plz skips
+# `publish = false` packages, so only eql-bindings is ever released.
+publish = false
 
 [dependencies]
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "macros", "chrono", "rust_decimal"] }


### PR DESCRIPTION
Implements [CIP-3224](https://linear.app/cipherstash/issue/CIP-3224/publish-eql-bindings-crate).

## What

Set up `release-plz` to publish the **`eql-bindings`** crate to crates.io via **Trusted Publishing (OIDC)** — no long-lived token in the repo — and wire up testing + releasing workflows.

### New
- **`release-plz.toml`** — scopes the release to `eql-bindings` only (per-crate changelog, GitHub Release enabled). Every other workspace crate is now `publish = false`, which release-plz auto-skips.
- **`.github/workflows/release-plz.yml`** — on push to `main`: a `release` job (OIDC → short-lived crates.io token via `rust-lang/crates-io-auth-action`, then `release-plz release`) and a `release-pr` job.
- **`crates/eql-bindings/CHANGELOG.md`** — Keep-a-Changelog seed release-plz maintains.

### Changed
- **`crates/eql-bindings/Cargo.toml`** — added crates.io metadata. `license = "MIT"` was **required** (publish fails without it); plus `repository`, `homepage`, `readme`, `keywords`, `categories`.
- **`eql-domains` / `eql-tests-macros` / `eql_tests`** — `publish = false`. `cargo metadata` confirms `eql-bindings` is the only publishable crate.
- **`test-eql.yml`** — added a `cargo publish -p eql-bindings --dry-run` gate to the `rust-crates` job (catches publish-blockers on PRs).
- **`release-eql.yml` / `release-postgres-eql-image.yml` / `rebuild-docs.yml`** — excluded the `eql-bindings-v*` crate tag so a crate release never triggers the SQL build, Docker image, or docs-site rebuild.
- **`.github/workflows/README.md`** — documented the workflow + the two-tag-family contract (`eql-<semver>` = SQL surface; `eql-bindings-v<semver>` = crate).

## Verified
- `cargo publish -p eql-bindings --dry-run` packages **and** compiles cleanly (dev-dep on `eql-domains` correctly dropped).
- `cargo metadata` → only `eql-bindings` is publishable.
- All touched workflow YAML + `release-plz.toml` parse.

## Manual setup required before first publish
1. **crates.io Trusted Publishing** — on the `eql-bindings` crate: Settings → Trusted Publishing, add owner `cipherstash`, repo `encrypt-query-language`, workflow `release-plz.yml`. For a new crate name, pre-register the publisher before the first publish.
2. **`RELEASE_PLZ_TOKEN` secret (recommended)** — PRs opened by the default `GITHUB_TOKEN` don't trigger `test-eql.yml`, so the release PR would get no CI and couldn't satisfy the required `ci-required` check. Add a fine-grained PAT / GitHub App token as `RELEASE_PLZ_TOKEN`; the workflow picks it up automatically (falls back to `GITHUB_TOKEN`).