### PR TITLE
chore(bindings): bump eql-bindings to 0.2.0 for the first crates.io release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "eql-bindings"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "eql-domains",
  "schemars",

--- a/crates/eql-bindings/CHANGELOG.md
+++ b/crates/eql-bindings/CHANGELOG.md
@@ -4,3 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-07-03
+
+### Changed
+
+- **BREAKING**: the EQL envelope version is now `v: 3` (was `v: 2`) —
+  `EQL_SCHEMA_VERSION`, the `SchemaVersion` newtype, the emitted TypeScript
+  alias, and the JSON Schema `const` accept exactly `3`, matching the
+  `eql_v3` domain CHECKs.
+
+### Added
+
+- `from_v2` — EQL v2.3 → v3 wire payload conversion: `from_v2(&Value,
+  TargetDomain)` for storage payloads (fail-closed on missing terms, drops
+  the v2 `k` discriminator, strict-parses through the target binding type),
+  `from_v2_query` for jsonb containment needles, and `is_v3_payload` for
+  envelope sniffing. Zero cipherstash-client dependency.
+- SteVec (encrypted JSONB) document surface: `SteVecDocument` (carrying the
+  `k: "sv"` form discriminator), entry/query types, and the `OreCllw` /
+  `Selector` term newtypes, with generated inventory, TypeScript bindings,
+  and JSON Schemas.
+- CLLW-OPE ordering term: the `OpeCllw` newtype (`op` wire key) and the
+  `<T>OrdOpe` binding types for every ordered scalar family.
+- `TargetDomain::parse` resolving domain names via the catalog-generated
+  inventory; `term_json_keys` / `parse_value` threaded through `DomainType`.

--- a/crates/eql-bindings/Cargo.toml
+++ b/crates/eql-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eql-bindings"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Canonical wire types for EQL payloads — single source of truth for Rust, TypeScript (ts-rs), and JSON Schema (schemars)."
 # crates.io metadata. `license` is REQUIRED by crates.io — publish fails without


### PR DESCRIPTION
Version bump + CHANGELOG entry for the `eql-bindings` **0.2.0** release ([CIP-3346](https://linear.app/cipherstash/issue/CIP-3346)). 0.1.0 shipped to crates.io on 2026-07-01 (PR #334); 0.2.0 covers everything since:

- **BREAKING**: envelope version `v: 2` → `v: 3` (`SchemaVersion`, TS alias, JSON Schema `const`), matching the `eql_v3` domain CHECKs
- `from_v2` conversion module (v2.3 → v3 wire payloads, `from_v2_query`, `is_v3_payload`)
- SteVec document surface (`SteVecDocument` with `k: "sv"`, entry/query types, `OreCllw`/`Selector` newtypes)
- CLLW-OPE term (`OpeCllw`, `<T>OrdOpe` binding types)
- `term_json_keys` / `parse_value` threaded through `DomainType`

`cargo publish --dry-run -p eql-bindings` passes on this branch: packages standalone (eql-domains is dev-only; generated bindings committed in-crate), no path-dep leakage.

Release will be run **manually** after this merges — the `release-plz.yml` workflow isn't registered/dispatchable until it exists on `main` (waits on the `eql_v3` → `main` merge). Tag as `eql-bindings-v0.2.0` so the `eql`-keyed SQL release workflows don't fire.