### PR TITLE
docs(fixtures): FIXTURE_SCHEMA.md rename sweep + eql-bindings 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "eql-bindings"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "eql-domains",
  "schemars",

--- a/crates/eql-bindings/CHANGELOG.md
+++ b/crates/eql-bindings/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-07-03
+
+### Fixed
+
+- The `from_v2_query_typed` rustdoc links only public items, fixing the
+  `private_intra_doc_links` lint on docs.rs builds. No API changes.
+
 ## [0.4.0] - 2026-07-03
 
 ### Added

--- a/crates/eql-bindings/Cargo.toml
+++ b/crates/eql-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eql-bindings"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Canonical wire types for EQL payloads — single source of truth for Rust, TypeScript (ts-rs), and JSON Schema (schemars)."
 # crates.io metadata. `license` is REQUIRED by crates.io — publish fails without

--- a/tests/sqlx/fixtures/FIXTURE_SCHEMA.md
+++ b/tests/sqlx/fixtures/FIXTURE_SCHEMA.md
@@ -19,13 +19,13 @@ Generated eql_v3 fixtures (gitignored)
   ├── eql_v3_<T>_doubles.sql   (jsonb payload — duplicate-value variant the
   │                             property suites consume)
   ├── v3_numeric_collision.sql (jsonb payload — no EQL dependency)
-  ├── v3_doc_int4.sql          (eql_v3.json payload — depends on eql_v3 surface)
+  ├── v3_doc_integer.sql       (eql_v3.json payload — depends on eql_v3 surface)
   └── v3_ste_vec.sql           (eql_v3.json payload — depends on eql_v3 surface)
 ```
 
 The scalar fixtures (`eql_v3_<T>.sql`) have **no EQL dependency** — `payload` is
 plain `jsonb`, so each script applies standalone. The document fixtures
-(`v3_doc_int4.sql`, `v3_ste_vec.sql`) depend on the `eql_v3` encrypted-JSONB
+(`v3_doc_integer.sql`, `v3_ste_vec.sql`) depend on the `eql_v3` encrypted-JSONB
 surface being installed.
 
 **Regenerated every test run.** `mise run test:sqlx` invokes the generator
@@ -37,11 +37,11 @@ environment (they are not alternatives): `CS_CLIENT_ACCESS_KEY` +
 `CS_CLIENT_KEY` for the client key (EnvKeyProvider). Do not hand-edit a
 generated file; it is overwritten in place on every run.
 
-**Schema (e.g. `eql_v3_int4`):** Tables live in the dedicated `fixtures` SQL
+**Schema (e.g. `eql_v3_integer`):** Tables live in the dedicated `fixtures` SQL
 schema (kept out of the `public`/`eql_v3` type namespaces):
 ```sql
 CREATE SCHEMA IF NOT EXISTS fixtures;
-CREATE TABLE fixtures.eql_v3_int4 (
+CREATE TABLE fixtures.eql_v3_integer (
   id BIGINT PRIMARY KEY,
   plaintext integer NOT NULL,
   payload jsonb NOT NULL
@@ -54,10 +54,10 @@ CREATE TABLE fixtures.eql_v3_int4 (
   pivots) plus small/medium/large magnitudes.
 - `plaintext` is the **in-table oracle**: consuming tests filter
   `WHERE plaintext = N` directly, so no Rust value constant is shared.
-- Each `payload` is a cipherstash-client-encrypted JSONB object carrying
-  `c` (ciphertext), `hm` (HMAC equality term), `ob` (ORE block ordering term),
-  an inert `i` metadata object, and the EQL payload discriminator
-  (`k = "ct"`, `v = 2`).
+- Each `payload` is a cipherstash-client-encrypted JSONB object converted to
+  the v3 envelope via `eql_bindings::from_v2`, carrying `c` (ciphertext),
+  `hm` (HMAC equality term), `ob` (ORE block ordering term), an inert `i`
+  metadata object, and `v = 3` (v3 scalars carry no `k` discriminator).
 
 **Used By:**
 - the `__scalar_matrix_fixture_shape!` arm in `tests/sqlx/src/matrix.rs`
@@ -67,7 +67,7 @@ CREATE TABLE fixtures.eql_v3_int4 (
 
 **Opt-in:** Each consuming test opts in explicitly:
 ```rust
-#[sqlx::test(fixtures(path = "../fixtures", scripts("eql_v3_int4")))]
+#[sqlx::test(fixtures(path = "../fixtures", scripts("eql_v3_integer")))]
 ```
 
 ---


### PR DESCRIPTION
## Summary

Two small housekeeping changes:

**`FIXTURE_SCHEMA.md` missed the `int4` → `integer` rename sweep.** Fixed the stale references: `v3_doc_int4.sql` → `v3_doc_integer.sql`, `eql_v3_int4` → `eql_v3_integer` in the schema and opt-in examples, and the payload envelope description — the doc still claimed the v2 envelope (`k = "ct"`, `v = 2`), but generated fixtures are converted to the v3 envelope via `eql_bindings::from_v2` (`v = 3`, no `k` on scalars; see `tests/sqlx/src/fixtures/mod.rs` and `spec.rs`). Also deleted a stale untracked local stub under the old name (not part of the diff — it was never tracked).

**Bump eql-bindings to 0.4.1.** Ships the changes since 0.4.0: the `private_intra_doc_links` rustdoc fix on `from_v2_query_typed` (19207a27). No API changes, so a patch bump. Release remains manual (CIP-3346) until `eql_v3` merges to `main`.

## Verification

- `cargo test -p eql-bindings` — 109 passed
- `cargo publish --dry-run -p eql-bindings` — passes
- `grep int4 tests/sqlx/fixtures/FIXTURE_SCHEMA.md` — no stale references remain