### PR TITLE
docs: sync v3 schema references to public domains

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,7 +85,7 @@ These are the important files and directories in the repo:
 │   │   ├── sem/               <-- hand-written SEM index-term types (hmac_256, ore_block_256, …)
 │   │   ├── scalars/           <-- generated scalar domain families, one dir per type
 │   │   │   ├── functions.sql  <-- shared blocker for native jsonb operators
-│   │   │   └── <T>/           <-- e.g. integer/, text/, bool/ (generated, committed in place)
+│   │   │   └── <T>/           <-- e.g. integer/, text/, boolean/ (generated, committed in place)
 │   │   ├── jsonb/             <-- jsonb SteVec support
 │   │   └── lint/              <-- structural lints
 │   ├── deps-v3.txt            <-- REQUIRE edges for the v3 surface

--- a/README.md
+++ b/README.md
@@ -70,19 +70,19 @@ EQL installs the following components into the `eql_v3` schema:
 
 | Name                                                | Entity Type   | Purpose                                                              |
 | --------------------------------------------------- | ------------- | ------------------------------------------------------------------- |
-| `eql_v3`                                            | Schema        | Holds all EQL types, operators, functions, and aggregates           |
-| `eql_v3.<T>`, `eql_v3.<T>_eq`, `eql_v3.<T>_ord`     | Domain types  | Per-scalar encrypted columns (one family per scalar: `integer`, `text`, `timestamp`, …) |
+| `eql_v3`                                            | Schema        | Holds EQL operators, term extractors, comparison wrappers, and aggregates |
+| `public.<T>`, `public.<T>_eq`, `public.<T>_ord`     | Domain types  | Per-scalar encrypted columns (one family per scalar: `integer`, `text`, `timestamp`, …) |
 | `public.json`                                       | Domain type   | Encrypted JSON (structured-encryption) documents                    |
 | `eql_v3.eq_term` / `ord_term` / `match_term`        | Functions     | Index-term extractors for functional indexes                        |
 
 
 ### `eql_v3` Schema
 
-The `eql_v3` schema holds the encrypted-domain types, their operators and term extractors, and the `MIN` / `MAX` aggregates.
+The `eql_v3` schema holds the operators, term extractors, comparison wrappers, and `MIN` / `MAX` aggregates for the encrypted-domain types. The encrypted-domain types themselves live in `public` (see below), and the internal SEM index-term types live in `eql_v3_internal`.
 
-Encrypted columns are typed as `eql_v3` domains (e.g. `public.text_eq`, `public.json`), and the searchable surface available on a column is fixed by its domain **variant** — there is no database-side configuration state. Which index terms a value carries is decided by the encryption client (CipherStash Stack / CipherStash Proxy).
+Encrypted columns are typed as `public` domains (e.g. `public.text_eq`, `public.json`), and the searchable surface available on a column is fixed by its domain **variant** — there is no database-side configuration state. Which index terms a value carries is decided by the encryption client (CipherStash Stack / CipherStash Proxy).
 
-Because the domain types live in the `eql_v3` schema, columns depend on them; `DROP SCHEMA eql_v3 CASCADE` removes the surface (and would drop columns typed as those domains). Re-running the install script is idempotent.
+The domain types deliberately live in `public`, not `eql_v3`, so application tables survive an EQL uninstall: `DROP SCHEMA eql_v3 CASCADE` removes the operators, extractors, and aggregates but leaves the `public`-typed columns (and their data) intact. Re-running the install script is idempotent.
 
 
 ## Database Permissions
@@ -165,7 +165,7 @@ Once EQL is installed in your PostgreSQL database, you can start using encrypted
 
 ### Enable encrypted columns
 
-Define encrypted columns using an `eql_v3` domain type. Type the column as the **variant** for the capability you need — `public.text_eq` for equality, `eql_v3.<T>_ord` for range/ordering, `public.text_match` for full-text, `public.json` for encrypted JSON. Each is stored as `jsonb` with a `CHECK` constraint that validates the encrypted payload.
+Define encrypted columns using a `public` encrypted-domain type. Type the column as the **variant** for the capability you need — `public.text_eq` for equality, `public.<T>_ord` for range/ordering, `public.text_match` for full-text, `public.json` for encrypted JSON. Each is stored as `jsonb` with a `CHECK` constraint that validates the encrypted payload.
 
 **Example:**
 
@@ -262,9 +262,9 @@ Verify documentation quality using these scripts:
 mise run docs:validate
 
 # Or run individual checks
-./tasks/check-doc-coverage.sh      # Check 100% coverage
-./tasks/validate-required-tags.sh  # Validate @brief, @param, @return
-./tasks/validate-documented-sql.sh # Validate SQL syntax
+./tasks/docs/validate/coverage.sh       # Check 100% coverage
+./tasks/docs/validate/required-tags.sh  # Validate @brief, @param, @return
+./tasks/docs/validate/documented-sql.sh # Validate SQL syntax
 ```
 
 Documentation validation runs automatically in CI for all pull requests.

--- a/SUPABASE.md
+++ b/SUPABASE.md
@@ -17,7 +17,7 @@ and Supabase [does not support custom operators](https://github.com/supabase/sup
 so that recipe needed a cut-down build.
 
 `eql_v3` removes the dependency entirely. Every encrypted column is typed as
-a `jsonb`-backed **domain** in the `eql_v3` schema (for example
+a `jsonb`-backed **domain** in the `public` schema (for example
 `public.text_eq`, `public.integer_ord`, `public.json`), and search is driven by
 **functional indexes over small term-extractor functions** rather than an
 operator class on the column:
@@ -60,8 +60,8 @@ type it as**, and which index terms travel in a value's payload is decided by
 the encryption client — [CipherStash Proxy](https://github.com/cipherstash/proxy)
 or [CipherStash Stack](https://github.com/cipherstash/stack):
 
-- `eql_v3.<T>_eq` carries an `hm` term — supports `=` / `<>`, `GROUP BY`, `DISTINCT`.
-- `eql_v3.<T>_ord` (and the `_ord_ore` twin) carries an `ob` term — adds `<` `<=` `>` `>=`, `ORDER BY`, `MIN` / `MAX`.
+- `public.<T>_eq` carries an `hm` term — supports `=` / `<>`, `GROUP BY`, `DISTINCT`.
+- `public.<T>_ord` (and the `_ord_ore` twin) carries an `ob` term — adds `<` `<=` `>` `>=`, `ORDER BY`, `MIN` / `MAX`.
 - `public.text_match` carries a `bf` term — supports bloom-filter token containment (`@>` / `<@`).
 - `public.text_search` carries all three terms — equality, ordering, and containment on `text`.
 
@@ -142,7 +142,7 @@ for the full explanation.
 ### Aggregates `MIN` / `MAX`
 
 `MIN` / `MAX` are exposed on the ordered variants as
-`eql_v3.min(eql_v3.<T>_ord)` / `eql_v3.max(eql_v3.<T>_ord)` (and the
+`eql_v3.min(public.<T>_ord)` / `eql_v3.max(public.<T>_ord)` (and the
 `_ord_ore` twin). Type the column as `_ord`, or cast at the call site:
 
 ```sql

--- a/docs/reference/adding-a-scalar-encrypted-domain-type.md
+++ b/docs/reference/adding-a-scalar-encrypted-domain-type.md
@@ -8,10 +8,12 @@ Read top-down to ship a type; drop into the reference half when something
 breaks or you need the *why*.
 
 A scalar encrypted-domain type is a family of concrete `jsonb` domains in the
-**`eql_v3`** schema (`eql_v3.<token>`, `eql_v3.<token>_eq`,
-`eql_v3.<token>_ord`, …), dropped by `DROP SCHEMA eql_v3 CASCADE`. Their
+**`public`** schema (`public.<token>`, `public.<token>_eq`,
+`public.<token>_ord`, …). The domains deliberately live in `public`, **not**
+`eql_v3`, so that application columns typed as an encrypted domain survive an
+uninstall: `DROP SCHEMA eql_v3 CASCADE` does **not** drop them. Their
 extractors, comparison wrappers, and MIN/MAX
-aggregates also live in `eql_v3`; the searchable-encrypted-metadata (SEM)
+aggregates — the callable surface — do live in `eql_v3`; the searchable-encrypted-metadata (SEM)
 index-term types they return (`eql_v3_internal.hmac_256`,
 `eql_v3_internal.ore_block_256`, `eql_v3_internal.ope_cllw`) live in the
 **`eql_v3_internal`** schema — hand-written under
@@ -40,7 +42,7 @@ To add a scalar type `<T>` (e.g. `bigint`), with Rust type `<R>` (e.g. `i64`):
    plaintext fixture `values`) in the `fixtures` module (§2). If the type needs a
    new scalar width, add a `ScalarKind` variant first; if it needs new term
    behaviour, that goes in the `Term` enum's `impl`, never in catalog data.
-2. **Materialise the value list** — `int_values!(<T_UPPER>_VALUES, <R>, <T_UPPER>);`
+2. **Materialise the value list** — `int_values!(<T_UPPER>_VALUES, <R>, <T_UPPER>_FIXTURES);`
    next to `CATALOG`, pinned by a `values_tests` assertion (§2). This is the
    single source the SQLx matrix reads; there is no generated `<T>_values.rs`.
 3. **Wire the SQLx matrix oracle** — for an integer type, copy the two small
@@ -98,15 +100,15 @@ with a `TypeFixtures` record in
 
 ```rust
 // The structural catalog row — name + domains only:
-const INT4: DomainFamily = DomainFamily {
+const INTEGER: DomainFamily = DomainFamily {
     name: "integer",
     domains: ORDERED_INT_DOMAINS, // storage, _eq (hm), _ord_ore (ore), _ord (ore), _ord_ope (ope)
 };
 
 // The fixture-layer record — kind + plaintext values — joined back to the
 // catalog row by `family.name`:
-pub const INT4_FIXTURES: TypeFixtures = TypeFixtures {
-    family: &crate::INT4,
+pub const INTEGER_FIXTURES: TypeFixtures = TypeFixtures {
+    family: &crate::INTEGER,
     kind: ScalarKind::I32,
     values: fixtures!(int i32;
         Min, N(-100), N(-1), Zero, N(1), N(2), N(5), N(10), N(17), N(25),
@@ -212,7 +214,7 @@ range-checks each `Int` literal against the kind at compile time (`N(-40000)`
 for an `i16` kind does not compile):
 
 ```rust
-// the `values:` expression of INT4_FIXTURES (a `TypeFixtures`):
+// the `values:` expression of INTEGER_FIXTURES (a `TypeFixtures`):
 values: fixtures!(int i32;
     Min, N(-100), N(-1), Zero, N(1), N(2), N(5), N(10), N(17), N(25),
     N(42), N(50), N(100), N(250), N(1000), N(9999), Max),
@@ -237,10 +239,10 @@ result counts, include useful boundaries, and cover omitted-term negative cases.
 
 The plaintext list is **not** rendered to a generated file. The `int_values!`
 macro (in `crates/eql-domains/src/fixtures/values.rs`) materialises a `Fixture` list into a typed `pub const
-<T_UPPER>_VALUES: &[<rust_type>]` at compile time (`INT4_VALUES`, `INT2_VALUES`):
+<T_UPPER>_VALUES: &[<rust_type>]` at compile time (`INTEGER_VALUES`, `SMALLINT_VALUES`):
 
 ```rust
-int_values!(INT4_VALUES, i32, INT4_FIXTURES);
+int_values!(INTEGER_VALUES, i32, INTEGER_FIXTURES);
 ```
 
 Both consumers reference that single symbol — the fixture generator
@@ -538,7 +540,7 @@ This is the contract the generated SQL satisfies. You normally never read it to
 
 The generator emits `src/v3/scalars/<T>/<T>_types.sql` (committed in place;
 regenerated on every build) with one idempotent `DO $$ ... $$` block. Every
-domain is a concrete domain over `jsonb` in the `eql_v3` schema — **never**
+domain is a concrete domain over `jsonb` in the `public` schema — **never**
 `CREATE DOMAIN a AS b` over another generated domain (PostgreSQL resolves
 operators against the underlying base type, bypassing the fixed surface). Each
 domain's `CHECK` requires:
@@ -737,7 +739,7 @@ unreachable. Invariants encoded in the renderers / templates and guarded by
 - **SQL-literal injection is structurally prevented** — every interpolated
   single-quoted literal passes through `sql_str`
   (`crates/eql-codegen/src/consts.rs`), which doubles embedded single quotes.
-- **No domain-over-domain** — every domain is `CREATE DOMAIN eql_v3.<name> AS
+- **No domain-over-domain** — every domain is `CREATE DOMAIN public.<name> AS
   jsonb` (`types_file_has_all_five_domains`).
 - **No operator class on a domain** — the generator emits operators, not
   operator classes.
@@ -795,19 +797,25 @@ ninety hand-written declarations that must agree with each other and with
 runs as `cargo run -p eql-codegen` (no subcommand), which calls
 `generate::generate_all` (`crates/eql-codegen/src/generate.rs`) over every row of
 `eql_domains::CATALOG`, writing each type's SQL into
-`src/v3/scalars/<token>/`. Three subcommands round out the surface:
-`-- list-types` prints the catalog tokens one per line (consumed by the fixture
-and matrix-inventory enumeration); `-- dump-catalog` prints the catalog surface
+`src/v3/scalars/<token>/`. Five subcommands round out the surface:
+`list-types` prints the catalog tokens one per line (consumed by the fixture
+and matrix-inventory enumeration); `list-schemas` prints the schemas the
+`eql_v3` surface owns, public first (consumed by `mise run test:schemas:parity`);
+`dump-catalog` prints the catalog surface
 (types → domains → supported operators) as JSON (consumed by the
-catalog-coverage / log-verification gates); and `-- bindings` regenerates the
+catalog-coverage / log-verification gates); `bindings` regenerates the
 committed `eql-bindings` Rust payload types (the first step of `mise run
-types:generate`). `main` (`crates/eql-codegen/src/main.rs`) recognises exactly
-these four forms (no-arg generate-all, `list-types`, `dump-catalog`,
-`bindings`); any other argument is a usage error.
+types:generate`); and `clean` removes the generated SQL surface (marker-aware).
+`main` (`crates/eql-codegen/src/main.rs`) recognises exactly
+these six forms (no-arg generate-all, `list-types`, `list-schemas`,
+`dump-catalog`, `bindings`, `clean`); any other argument is a usage error.
 
-The generator targets two schemas: `SCHEMA = "eql_v3"`
-(`crates/eql-codegen/src/consts.rs`) qualifies the domain families and the
-public callable surface, while `INTERNAL_SCHEMA = "eql_v3_internal"` qualifies
+The generator targets three schemas. The **domain families themselves are
+created in `public`** (`CREATE DOMAIN public.<name> AS jsonb`) so application
+columns survive an `eql_v3` uninstall. `SCHEMA = "eql_v3"`
+(`crates/eql-codegen/src/consts.rs`) qualifies only the **callable surface** —
+the extractors, comparison wrappers, and aggregates — while
+`INTERNAL_SCHEMA = "eql_v3_internal"` qualifies
 the SEM index-term types the extractors return (`eql_v3_internal.hmac_256`,
 `eql_v3_internal.ore_block_256`, `eql_v3_internal.ope_cllw`) and the aggregate
 state functions, so the generated SQL is entirely self-contained within the two
@@ -969,8 +977,8 @@ What makes it storage-only:
   term-less storage domain); it is *also* `is_eq_only()` (no `_ord`), so the
   harness checks storage-only **first**.
 - **Generator: no changes needed.** The SQL generator already handles a
-  zero-term, single-domain type — it emits exactly three files (`bool_types.sql`,
-  `bool_functions.sql`, `bool_operators.sql`; no `_aggregates.sql`, since no
+  zero-term, single-domain type — it emits exactly three files (`boolean_types.sql`,
+  `boolean_functions.sql`, `boolean_operators.sql`; no `_aggregates.sql`, since no
   ordered domain). All 44 functions are `plpgsql` blockers, all 44 `CREATE OPERATOR` statements back
   onto them: every comparison/containment/path operator reachable through domain
   fallback raises. The domain `CHECK` still pins `{v,i,c}` + `VALUE->>'v' = '3'`.
@@ -1005,6 +1013,6 @@ What makes it storage-only:
   (`shape="storage_only"`).
 
 Everything else is the standard path: one catalog row, regenerate, commit the
-generated `src/v3/scalars/bool/` SQL (3 files), no edits to
+generated `src/v3/scalars/boolean/` SQL (3 files), no edits to
 `pin_search_path_v3.sql` or `splinter.sh` (a storage-only type emits only blockers
 — no extractors/wrappers/aggregates, so no new inline-critical names).

--- a/docs/reference/adding-a-scalar-encrypted-domain-type.md
+++ b/docs/reference/adding-a-scalar-encrypted-domain-type.md
@@ -800,7 +800,7 @@ runs as `cargo run -p eql-codegen` (no subcommand), which calls
 `src/v3/scalars/<token>/`. Five subcommands round out the surface:
 `list-types` prints the catalog tokens one per line (consumed by the fixture
 and matrix-inventory enumeration); `list-schemas` prints the schemas the
-`eql_v3` surface owns, public first (consumed by `mise run test:schemas:parity`);
+`eql_v3` surface owns (`eql_v3`, then `eql_v3_internal`; consumed by `mise run test:schemas:parity`);
 `dump-catalog` prints the catalog surface
 (types → domains → supported operators) as JSON (consumed by the
 catalog-coverage / log-verification gates); `bindings` regenerates the

--- a/docs/reference/catalog-driven-architecture.md
+++ b/docs/reference/catalog-driven-architecture.md
@@ -16,9 +16,9 @@ gates guarantee the derived artifacts never drift from it.
 ```mermaid
 flowchart TD
     subgraph SOT["① SOURCE OF TRUTH — crates/eql-domains"]
-        CAT["CATALOG: &[DomainFamily]<br/>(10 scalar families)"]
+        CAT["CATALOG: &[DomainFamily]<br/>(11 families: 10 scalar + jsonb)"]
         FIX["FIXTURES: &[TypeFixtures]<br/>(plaintext value lists)"]
-        TERM["Term enum impls<br/>(Hm / Ore / Bloom capabilities)"]
+        TERM["Term enum impls<br/>(Hm / Ore / Bloom / Ope capabilities)"]
         CAT -.compile-time parity guard.- FIX
     end
 
@@ -70,12 +70,13 @@ Everything starts in `crates/eql-domains/src/lib.rs`:
 
 ```rust
 pub const CATALOG: &[DomainFamily] = &[
-    INT4, INT2, INT8, DATE, TIMESTAMP,
-    NUMERIC, TEXT, BOOL, FLOAT4, FLOAT8,
+    INTEGER, SMALLINT, BIGINT, DATE, TIMESTAMP, NUMERIC, TEXT, BOOLEAN, REAL, DOUBLE, JSONB,
 ];
 ```
 
 Order is **load-bearing** — it drives generation order, inventory order, and snapshot order.
+Ten of the eleven rows are `Shape::Scalar` families; the eleventh, `JSONB`, is the hand-written
+SteVec family (see §2.3). Scalar-only consumers iterate `scalar_families()`, which filters `JSONB` out.
 
 ### 2.1 The data model
 
@@ -86,7 +87,7 @@ classDiagram
         +domains: &[Domain]
     }
     class Domain {
-        +name: &str        // "", "eq", "ord", "ord_ore", "match", "search"
+        +name: &str        // "", "eq", "ord", "ord_ore", "ord_ope", "match", "search"
         +terms: &[Term]
     }
     class Term {
@@ -94,6 +95,7 @@ classDiagram
         Hm
         Ore
         Bloom
+        Ope
     }
     class Role {
         <<enum>>
@@ -121,8 +123,8 @@ classDiagram
 
 - **`DomainFamily`** = one scalar type (`name` + the public domains it carries).
 - **`Domain`** = one operator/index capability surface (a bare suffix + fixed terms). The empty
-  name `""` is the storage-only domain (`public.integer`); `eq`, `ord`, `ord_ore`, `match`,
-  `search` are the searchable ones.
+  name `""` is the storage-only domain (`public.integer`); `eq`, `ord`, `ord_ore`, `ord_ope`,
+  `match`, `search` are the searchable ones.
 - **`Term`** = an index-term type. *This is where capability lives.*
 
 ### 2.2 The `Term` enum is the capability engine
@@ -130,15 +132,21 @@ classDiagram
 A `Term` answers every question the generators need, via exhaustive `impl` methods
 (`crates/eql-domains/src/term.rs`). This table *is* the contract:
 
-| Method | `Hm` | `Ore` | `Bloom` |
-|--------|------|-------|---------|
-| `json_key()` | `"hm"` | `"ob"` | `"bf"` |
-| `extractor()` | `eq_term` | `ord_term` | `match_term` |
-| `ctor()` | `hmac_256` | `ore_block_256` | `bloom_filter` |
-| `binding_newtype()` | `Hmac256` | `OreBlock256` | `BloomFilter` |
-| `role()` | `Eq` | `Ord` | `Match` |
-| `operators()` | `= <>` | `= <> < <= > >=` | `@> <@` |
-| `provides_ordering()` | `false` | `true` | `false` |
+| Method | `Hm` | `Ore` | `Bloom` | `Ope` |
+|--------|------|-------|---------|-------|
+| `json_key()` | `"hm"` | `"ob"` | `"bf"` | `"op"` |
+| `extractor()` | `eq_term` | `ord_term` | `match_term` | `ord_ope_term` |
+| `ctor()` | `hmac_256` | `ore_block_256` | `bloom_filter` | `ope_cllw` |
+| `binding_newtype()` | `Hmac256` | `OreBlock256` | `BloomFilter` | `OpeCllw` |
+| `role()` | `Eq` | `Ord` | `Match` | `Ord` |
+| `operators()` | `= <>` | `= <> < <= > >=` | `@> <@` | `= <> < <= > >=` |
+| `provides_ordering()` | `false` | `true` | `false` | `true` |
+
+`Ope` is the CLLW-OPE term: a hex-encoded ciphertext that is natively `bytea`-sortable after
+hex-decode (no custom comparison protocol), so — like `Hm` — its extractor is the whole SEM
+surface and it deliberately does *not* reuse `ord_term`'s extractor name (a shared name would
+collapse a mixed `[Ore, Ope]` domain under `dedupe_terms_by(Term::extractor)`).
+`provides_ordering()` is `true` for **both** `Ore` and `Ope`.
 
 Cross-term helpers compose these into the per-domain answers the renderers consume:
 `operators_for_terms`, `term_json_keys`, `payload_terms`, `nonempty_array_keys`,
@@ -161,11 +169,11 @@ fail loudly if they drift into an unreviewed shape. The eleventh `CATALOG` famil
 flowchart LR
     subgraph ordered["ordered (8 families)"]
         direction TB
-        o1["storage []"] --> o2["_eq [Hm]"] --> o3["_ord_ore [Ore]"] --> o4["_ord [Ore]"]
+        o1["storage []"] --> o2["_eq [Hm]"] --> o3["_ord_ore [Ore]"] --> o4["_ord [Ore]"] --> o5["_ord_ope [Ope]"]
     end
     subgraph text["text-search (text)"]
         direction TB
-        t1["storage []"] --> t2["_eq [Hm]"] --> t3["_match [Bloom]"] --> t4["_ord_ore [Hm,Ore]"] --> t5["_ord [Hm,Ore]"] --> t6["_search [Hm,Ore,Bloom]"]
+        t1["storage []"] --> t2["_eq [Hm]"] --> t3["_match [Bloom]"] --> t4["_ord_ore [Hm,Ore]"] --> t5["_ord [Hm,Ore]"] --> t6["_ord_ope [Hm,Ope]"] --> t7["_search [Hm,Ore,Bloom]"]
     end
     subgraph storage["storage-only (bool)"]
         s1["storage []"]
@@ -205,8 +213,8 @@ hand-written in `crates/eql-bindings/src/v3/jsonb.rs` — only inventory members
 that names/kinds align by index — a mismatch is a *build error*, not a runtime surprise.
 
 ```rust
-pub const INT4_FIXTURES: TypeFixtures = TypeFixtures {
-    family: &crate::INT4,
+pub const INTEGER_FIXTURES: TypeFixtures = TypeFixtures {
+    family: &crate::INTEGER,
     kind: ScalarKind::I32,
     values: fixtures!(int i32;
         Min, N(-100), N(-1), Zero, N(1), /* ... */ N(9999), Max),
@@ -214,7 +222,7 @@ pub const INT4_FIXTURES: TypeFixtures = TypeFixtures {
 ```
 
 The `int_values!` / `text_values!` macros materialize these to typed const slices
-(`INT4_VALUES: &[i32]`, `TEXT_VALUES: &[&str]`) at compile time — resolving `Min`/`Max`/`Zero`
+(`INTEGER_VALUES: &[i32]`, `TEXT_VALUES: &[&str]`) at compile time — resolving `Min`/`Max`/`Zero`
 sentinels to kind bounds and **panicking the build on an out-of-range integer literal**. No
 generated `.rs` round-trip; the source of truth is the catalog row itself.
 
@@ -222,16 +230,20 @@ generated `.rs` round-trip; the source of truth is the catalog row itself.
 
 ## 3. Layer ② — The Generator (`eql-codegen`)
 
-The CLI (`crates/eql-codegen/src/main.rs`) has five modes:
+The CLI (`crates/eql-codegen/src/main.rs`) has six modes:
 
 ```mermaid
 flowchart LR
     CLI["eql-codegen"] --> A["(no args)<br/>generate_all → SQL surface"]
     CLI --> B["bindings<br/>generate_bindings → Rust bindings"]
     CLI --> E["clean<br/>clean_all → remove generated SQL"]
-    CLI --> C["list-types<br/>catalog tokens, one per line"]
+    CLI --> C["list-types<br/>scalar_families() tokens, one per line"]
+    CLI --> F["list-schemas<br/>owned schemas (public first)"]
     CLI --> D["dump-catalog<br/>JSON of types→domains→ops"]
 ```
+
+`list-schemas` prints the schemas the `eql_v3` surface owns (`eql_v3`, then `eql_v3_internal`),
+consumed by `test:schemas:parity` to keep the Rust consts and the SQL `owned_schemas()` array in lockstep.
 
 Both generators follow the same crash-safe **render-all → preflight → write-all →
 delete-orphans** model, so a render panic or write error can never leave the tree
@@ -278,9 +290,9 @@ Each `*_functions.sql` mixes three entry kinds, selected per operator:
 
 | Kind | Template | Language | Purpose |
 |------|----------|----------|---------|
-| **Extractor** | `extractor.sql.j2` | `LANGUAGE sql` (inlinable) | `eq_term(integer_eq) → hmac_256` |
-| **Wrapper** | `wrapper.sql.j2` | `LANGUAGE sql` (inlinable) | `eq(a,b) → eq_term(a)=eq_term(b)` |
-| **Blocker** | `unsupported.sql.j2` | **`LANGUAGE plpgsql`** | `RAISE EXCEPTION 'operator % not supported'` |
+| **Extractor** | `functions/extractor.sql.j2` | `LANGUAGE sql` (inlinable) | `eq_term(integer_eq) → hmac_256` |
+| **Wrapper** | `functions/wrapper.sql.j2` | `LANGUAGE sql` (inlinable) | `eq(a,b) → eq_term(a)=eq_term(b)` |
+| **Blocker** | `functions/unsupported.sql.j2` | **`LANGUAGE plpgsql`** | `RAISE EXCEPTION 'operator % not supported'` |
 
 > **Two footguns the renderers enforce structurally (with tests):**
 > - **Blockers are never `STRICT`** — a `STRICT` blocker returns `NULL` on `NULL` args,
@@ -337,16 +349,22 @@ distinctions become visible — e.g. `text_ord` lists `v i c hm ob` (dual-term) 
 ```text
 src/v3/scalars/
 ├── functions.sql          ← hand-written shared blocker helper (COMMITTED)
-├── integer/
-│   ├── integer_types.sql            (generated, committed)
-│   ├── integer_functions.sql        (storage-only blockers)
-│   ├── integer_eq_functions.sql     (eq_term extractor + eq/neq wrappers)
-│   ├── integer_eq_operators.sql     (CREATE OPERATOR)
+├── integer/               (14 generated files)
+│   ├── integer_types.sql              (generated, committed)
+│   ├── integer_functions.sql          (storage-only blockers)
+│   ├── integer_operators.sql          (storage-only operator blockers)
+│   ├── integer_eq_functions.sql       (eq_term extractor + eq/neq wrappers)
+│   ├── integer_eq_operators.sql       (CREATE OPERATOR)
+│   ├── integer_ord_ore_functions.sql
+│   ├── integer_ord_ore_operators.sql
+│   ├── integer_ord_ore_aggregates.sql (min/max)
 │   ├── integer_ord_functions.sql
 │   ├── integer_ord_operators.sql
-│   ├── integer_ord_aggregates.sql   (min/max)
-│   ├── integer_ord_ore_*.sql
-│   └── integer_extensions.sql       ← hand-written, COMMITTED (if present)
+│   ├── integer_ord_aggregates.sql     (min/max)
+│   ├── integer_ord_ope_functions.sql
+│   ├── integer_ord_ope_operators.sql
+│   └── integer_ord_ope_aggregates.sql (min/max)
+│   (integer_extensions.sql ← hand-written, COMMITTED, only if present)
 └── ...
 ```
 
@@ -386,17 +404,17 @@ A generated struct (`integer.rs`):
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, TS, JsonSchema)]
 #[ts(export, export_to = "v3/")]
 #[serde(deny_unknown_fields)]
-pub struct Int4Eq {
+pub struct IntegerEq {
     pub v: SchemaVersion,
     pub i: Identifier,
     pub c: Ciphertext,
     pub hm: Hmac256,
 }
 
-impl DomainType for Int4Eq {
+impl DomainType for IntegerEq {
     fn sql_domain_static() -> &'static str { "public.integer_eq" }
     fn sql_domain(&self) -> &'static str { Self::sql_domain_static() }
-    fn schema(&self) -> Schema { schema_for!(Int4Eq) }
+    fn schema(&self) -> Schema { schema_for!(IntegerEq) }
 }
 ```
 
@@ -416,8 +434,8 @@ operator blocked).
 
 ```mermaid
 flowchart LR
-    RS["Rust structs<br/>#[derive(TS, JsonSchema)]"] -->|ts-rs export<br/>via cargo test -p eql-bindings| TS["crates/eql-bindings/bindings/v3/Int4Eq.ts<br/>(45 files)"]
-    RS -->|schemars via tests/export.rs<br/>injects $id| JS["crates/eql-bindings/schema/v3/integer_eq.json<br/>(39 files)"]
+    RS["Rust structs<br/>#[derive(TS, JsonSchema)]"] -->|ts-rs export<br/>via cargo test -p eql-bindings| TS["crates/eql-bindings/bindings/v3/IntegerEq.ts<br/>(63 files)"]
+    RS -->|schemars via tests/export.rs<br/>injects $id| JS["crates/eql-bindings/schema/v3/integer_eq.json<br/>(51 files)"]
 ```
 
 - **TypeScript:** one `.ts` per domain, importing co-located term types; newtypes become
@@ -443,14 +461,14 @@ plaintext values through cipherstash-client.
 
 ```mermaid
 flowchart TD
-    CV["eql_domains::INT4_VALUES<br/>(catalog plaintexts)"] --> SPEC["FixtureSpec::new(&quot;eql_v3_int4&quot;)<br/>.with_index(Unique).with_index(Ore)<br/>.with_values(INT4_VALUES)"]
+    CV["eql_domains::INTEGER_VALUES<br/>(catalog plaintexts)"] --> SPEC["FixtureSpec::new(&quot;eql_v3_integer&quot;)<br/>.with_index(Unique).with_index(Ore).with_index(Ope)<br/>.with_values(INTEGER_VALUES)"]
     SPEC --> RUN["spec().run()"]
     RUN --> ENC["cipherstash::encrypt_store()<br/>→ ZeroKMS (one batch round-trip)"]
     ENC --> INS["INSERT encrypted payloads into working table"]
-    INS --> SQL["tests/sqlx/fixtures/eql_v3_int4.sql<br/>(gitignored; {v,i,c,hm,ob} payloads)"]
+    INS --> SQL["tests/sqlx/fixtures/eql_v3_integer.sql<br/>(gitignored; {v,i,c,hm,ob,op} payloads)"]
 
     DISP["generate_all_fixtures.rs<br/>for spec in CATALOG"] --> RUN
-    DISP -.also.-> EXTRA["non-catalog fixtures<br/>(v3_ste_vec, v3_doc_int4,<br/>v3_numeric_collision, v3_text_empty,<br/>eql_v3_&lt;T&gt;_doubles)"]
+    DISP -.also.-> EXTRA["non-catalog fixtures<br/>(v3_ste_vec, v3_doc_integer,<br/>v3_numeric_collision, v3_text_empty,<br/>eql_v3_&lt;T&gt;_doubles)"]
 ```
 
 - The entry point (`generate_all_fixtures.rs`) **iterates `CATALOG` directly**, dispatching
@@ -458,7 +476,7 @@ flowchart TD
   with no fixture wiring fails, so silently-missing fixtures are impossible.
 - Gated behind `--features fixture-gen`; requires CipherStash creds (ZeroKMS + client key).
   **CI has them.** This is by design — there are *no* committed/static fixture exceptions.
-- Non-catalog fixtures (`v3_ste_vec`, `v3_doc_int4`, `v3_numeric_collision`,
+- Non-catalog fixtures (`v3_ste_vec`, `v3_doc_integer`, `v3_numeric_collision`,
   `v3_text_empty`, and per-type `eql_v3_<T>_doubles`) ride the same generation
   pipeline, so they are generated and gitignored too — not committed blobs.
 
@@ -521,6 +539,14 @@ A silently dropped, renamed, or `#[cfg]`-gated test fails the diff; a catalog ty
 its matrix wiring fails the `list-types` cross-check. When you change which matrix tests the
 macro emits, regenerate (`test:matrix:snapshots:regen`) and commit the baseline in the same
 change.
+
+Two **sibling** matrices sit beside these four scalar baselines, each with its own no-DB
+inventory gate:
+
+- `tests/sqlx/snapshots/ope_tests.txt` pins the CLLW-OPE (`<T>_ord_ope`) test-name set,
+  gated by `mise run test:matrix:inventory:ope`.
+- `tests/sqlx/snapshots/matrix_jsonb_entry_tests.txt` pins the `jsonb_entry::…` behaviour
+  matrix, gated by `mise run test:matrix:inventory:jsonb_entry`.
 
 ### 6.3 Determinism & drift gates
 
@@ -592,7 +618,7 @@ tests. Everything else is one row, the compiler, and the generators.
 | Fixture plaintexts | `crates/eql-domains/src/fixtures/record.rs`, `crates/eql-domains/src/fixtures/values.rs` |
 | Catalog invariant tests | `crates/eql-domains/src/tests.rs`, `crates/eql-domains/src/proptest_invariants.rs` |
 | CLI | `crates/eql-codegen/src/main.rs` |
-| SQL renderers | `crates/eql-codegen/src/generate.rs`, `crates/eql-codegen/src/context.rs`, `crates/eql-codegen/templates/*.j2` |
+| SQL renderers | `crates/eql-codegen/src/generate.rs`, `crates/eql-codegen/src/context.rs`, `crates/eql-codegen/templates/*.j2` (extractor/wrapper/unsupported templates under `crates/eql-codegen/templates/functions/*.j2`) |
 | Operator catalog | `crates/eql-codegen/src/operator_surface.rs` |
 | Bindings renderer | `crates/eql-codegen/src/bindings.rs` |
 | File-ownership guards | `crates/eql-codegen/src/writer.rs` |

--- a/docs/reference/catalog-driven-architecture.md
+++ b/docs/reference/catalog-driven-architecture.md
@@ -238,7 +238,7 @@ flowchart LR
     CLI --> B["bindings<br/>generate_bindings → Rust bindings"]
     CLI --> E["clean<br/>clean_all → remove generated SQL"]
     CLI --> C["list-types<br/>scalar_families() tokens, one per line"]
-    CLI --> F["list-schemas<br/>owned schemas (public first)"]
+    CLI --> F["list-schemas<br/>owned schemas (eql_v3 first)"]
     CLI --> D["dump-catalog<br/>JSON of types→domains→ops"]
 ```
 

--- a/docs/reference/database-indexes.md
+++ b/docs/reference/database-indexes.md
@@ -23,11 +23,11 @@ The model is simple and uniform across every encrypted-domain type: **index a fu
 Each capability has one canonical functional-index recipe. Type the column as the domain variant that carries the term (see [SQL support matrix](./sql-support.md)), then index the matching extractor:
 
 ```sql
--- Equality (hash index on the eq_term extractor) — eql_v3.<T>_eq / _ord / text_search
+-- Equality (hash index on the eq_term extractor) — public.<T>_eq / _ord / text_search
 CREATE INDEX users_email_eq
   ON users USING hash (eql_v3.eq_term(encrypted_email));
 
--- Ordering / range (btree index on the ord_term extractor) — eql_v3.<T>_ord / _ord_ore
+-- Ordering / range (btree index on the ord_term extractor) — public.<T>_ord / _ord_ore
 CREATE INDEX events_at_ord
   ON events USING btree (eql_v3.ord_term(encrypted_at));
 
@@ -72,8 +72,8 @@ For PostgreSQL to use a functional index on an encrypted column, **all** of thes
 
 Capability travels in the payload, chosen by the encryption client and reflected in the column's domain variant:
 
-- **Equality** needs an `hm` (hmac_256) term — `eql_v3.<T>_eq`, `eql_v3.<T>_ord`, or `public.text_search`.
-- **Range / ordering** needs an `ob` (ore_block_256) term — `eql_v3.<T>_ord` / `_ord_ore` or `public.text_search`.
+- **Equality** needs an `hm` (hmac_256) term — `public.<T>_eq`, `public.<T>_ord`, or `public.text_search`.
+- **Range / ordering** needs an `ob` (ore_block_256) term — `public.<T>_ord` / `_ord_ore` or `public.text_search`.
 - **Text containment** needs a `bf` (bloom_filter) term — `public.text_match` or `public.text_search`.
 
 A value with only a bloom term will not drive an equality index, and vice versa.
@@ -101,7 +101,7 @@ WHERE encrypted_email = '{"hm":"abc"}'::jsonb;
 
 ### Equality Queries
 
-A column typed `eql_v3.<T>_eq` (or `_ord`, or `text_search`) with a hash index on `eql_v3.eq_term(col)`:
+A column typed `public.<T>_eq` (or `_ord`, or `text_search`) with a hash index on `eql_v3.eq_term(col)`:
 
 ```sql
 CREATE INDEX users_email_eq ON users USING hash (eql_v3.eq_term(encrypted_email));

--- a/docs/reference/eql-functions.md
+++ b/docs/reference/eql-functions.md
@@ -1,6 +1,6 @@
 # EQL Functions Reference
 
-A reference for the functions and operators EQL exposes for querying encrypted data in PostgreSQL. The surface lives in the **`eql_v3`** schema and is organised around the per-scalar encrypted-domain types (`eql_v3.<T>` and variants) and the encrypted-JSON document type (`public.json`).
+A reference for the functions and operators EQL exposes for querying encrypted data in PostgreSQL. The surface lives in the **`eql_v3`** schema and is organised around the per-scalar encrypted-domain types (`public.<T>` and variants) and the encrypted-JSON document type (`public.json`).
 
 > **There is no database-side configuration API.** Which index terms a value carries is chosen by the encryption client ([CipherStash Proxy](https://github.com/cipherstash/proxy) / [CipherStash Stack](https://github.com/cipherstash/stack)); a column's capability is fixed by the **domain variant** you type it as. See [SQL support matrix](./sql-support.md) for the variant/operator table.
 
@@ -20,7 +20,7 @@ EQL overloads standard PostgreSQL operators on the encrypted-domain types. Type 
 
 ### Equality — `=` `<>`
 
-On `eql_v3.<T>_eq`, `eql_v3.<T>_ord` / `_ord_ore`, and `public.text_search` (carry an `hm` term):
+On `public.<T>_eq`, `public.<T>_ord` / `_ord_ore`, and `public.text_search` (carry an `hm` term):
 
 ```sql
 SELECT * FROM users WHERE encrypted_email = $1;
@@ -30,7 +30,7 @@ SELECT * FROM users WHERE encrypted_email <> $1;
 
 ### Range — `<` `<=` `>` `>=`
 
-On `eql_v3.<T>_ord` / `_ord_ore` and `public.text_search` (carry an `ob` ORE term):
+On `public.<T>_ord` / `_ord_ore` and `public.text_search` (carry an `ob` ORE term):
 
 ```sql
 SELECT * FROM events WHERE encrypted_at <  $1::public.timestamp_ord;
@@ -84,16 +84,16 @@ There are no `like` / `ilike` function forms — text matching is `eql_v3.contai
 
 ## Index Term Extraction
 
-These extract the index term from an encrypted-domain value. They are generated per eq/ord/match-capable variant of every scalar type, are inlinable (so a functional index on the extractor engages), and return the self-contained `eql_v3` SEM index-term types. See [Adding a Scalar Encrypted-Domain Type](./adding-a-scalar-encrypted-domain-type.md).
+These extract the index term from an encrypted-domain value. They are generated per eq/ord/match-capable variant of every scalar type, are inlinable (so a functional index on the extractor engages), and return the self-contained `eql_v3_internal` SEM index-term types. See [Adding a Scalar Encrypted-Domain Type](./adding-a-scalar-encrypted-domain-type.md).
 
 ```sql
 -- Equality term (hm)
-eql_v3.eq_term(a public.integer_eq)        RETURNS eql_v3.hmac_256
+eql_v3.eq_term(a public.integer_eq)        RETURNS eql_v3_internal.hmac_256
 -- Ordering term (ob)
-eql_v3.ord_term(a public.integer_ord)      RETURNS eql_v3.ore_block_256
-eql_v3.ord_term(a public.integer_ord_ore)  RETURNS eql_v3.ore_block_256
+eql_v3.ord_term(a public.integer_ord)      RETURNS eql_v3_internal.ore_block_256
+eql_v3.ord_term(a public.integer_ord_ore)  RETURNS eql_v3_internal.ore_block_256
 -- Text-match term (bf)
-eql_v3.match_term(a public.text_match)  RETURNS eql_v3.bloom_filter
+eql_v3.match_term(a public.text_match)  RETURNS eql_v3_internal.bloom_filter
 ```
 
 **Example — functional indexes on the extracted terms** (see [Database Indexes](./database-indexes.md)):
@@ -104,7 +104,7 @@ CREATE INDEX ON users USING btree (eql_v3.ord_term(salary_ord));
 CREATE INDEX ON users USING gin   (eql_v3.match_term(name_match));
 ```
 
-> The full per-domain operator / wrapper / blocker surface (and the `eql_v3.<T>` / `_eq` / `_ord` / `_ord_ore` domain types themselves) is documented in [SQL support](./sql-support.md#encrypted-domain-scalar-types-eql_v3t) and the [scalar encrypted-domain type reference](./adding-a-scalar-encrypted-domain-type.md).
+> The full per-domain operator / wrapper / blocker surface (and the `public.<T>` / `_eq` / `_ord` / `_ord_ore` domain types themselves) is documented in [SQL support](./sql-support.md#encrypted-domain-scalar-types-eql_v3t) and the [scalar encrypted-domain type reference](./adding-a-scalar-encrypted-domain-type.md).
 
 The `public.json` document type extracts entry-level terms with `eql_v3.eq_term(public.jsonb_entry)` and `eql_v3.ore_cllw(public.jsonb_entry)` — see [json-support.md](./json-support.md).
 
@@ -120,7 +120,7 @@ The full encrypted-JSONB function surface — containment, `->` / `->>`, `eql_v3
 
 ### `eql_v3.min()` / `eql_v3.max()` (per-domain)
 
-Returns the minimum or maximum encrypted value on an ordered encrypted-domain column. Defined per ord-capable variant of every scalar type (`eql_v3.<T>_ord`, `eql_v3.<T>_ord_ore`); the input type selects the aggregate via PostgreSQL's overload resolution.
+Returns the minimum or maximum encrypted value on an ordered encrypted-domain column. Defined per ord-capable variant of every scalar type (`public.<T>_ord`, `public.<T>_ord_ore`); the input type selects the aggregate via PostgreSQL's overload resolution.
 
 ```sql
 -- integer — generated for every ordered variant of every scalar type.

--- a/docs/reference/eql-functions.md
+++ b/docs/reference/eql-functions.md
@@ -104,7 +104,7 @@ CREATE INDEX ON users USING btree (eql_v3.ord_term(salary_ord));
 CREATE INDEX ON users USING gin   (eql_v3.match_term(name_match));
 ```
 
-> The full per-domain operator / wrapper / blocker surface (and the `public.<T>` / `_eq` / `_ord` / `_ord_ore` domain types themselves) is documented in [SQL support](./sql-support.md#encrypted-domain-scalar-types-eql_v3t) and the [scalar encrypted-domain type reference](./adding-a-scalar-encrypted-domain-type.md).
+> The full per-domain operator / wrapper / blocker surface (and the `public.<T>` / `_eq` / `_ord` / `_ord_ore` domain types themselves) is documented in [SQL support](./sql-support.md#encrypted-domain-scalar-types-publict) and the [scalar encrypted-domain type reference](./adding-a-scalar-encrypted-domain-type.md).
 
 The `public.json` document type extracts entry-level terms with `eql_v3.eq_term(public.jsonb_entry)` and `eql_v3.ore_cllw(public.jsonb_entry)` — see [json-support.md](./json-support.md).
 

--- a/docs/reference/json-support.md
+++ b/docs/reference/json-support.md
@@ -6,7 +6,7 @@ EQL encrypts, decrypts, and searches JSON / JSONB documents using structured enc
 
 - [Storing encrypted JSON](#storing-encrypted-json)
 - [Typed operands (important)](#typed-operands-important)
-- [Querying `public.json`](#querying-eql_v3json)
+- [Querying `public.json`](#querying-publicjson)
   - [Containment queries (`@>`, `<@`)](#containment-queries)
   - [Field extraction (`jsonb_path_query`)](#field-extraction-jsonb_path_query)
   - [JSON path operators (`->`, `->>`)](#json-path-operators)

--- a/docs/reference/sql-support.md
+++ b/docs/reference/sql-support.md
@@ -2,7 +2,7 @@
 
 This page summarises which SQL operators and language features work against EQL-encrypted columns, and which encrypted-domain **type** each one requires.
 
-EQL ships its searchable-encryption surface as PostgreSQL **domains in the `eql_v3` schema**:
+EQL ships its searchable-encryption surface as PostgreSQL **domains in the `public` schema**:
 
 - **per-scalar encrypted-domain types** — `public.integer`, `public.text`, `public.timestamp`, … — one family of domain *variants* per scalar; and
 - **an encrypted-JSON document type** — `public.json` — for structured-encryption (ste_vec) JSONB.
@@ -11,22 +11,22 @@ The capability of a column is fixed by the **domain variant you type it as**. Th
 
 ---
 
-## Encrypted-domain scalar types (`eql_v3.<T>`)
+## Encrypted-domain scalar types (`public.<T>`)
 
-Each scalar type `<T>` is a family of `jsonb`-backed domains in `eql_v3`. The catalog scalar tokens that ship today are:
+Each scalar type `<T>` is a family of `jsonb`-backed domains in `public`. The catalog scalar tokens that ship today are:
 
 `smallint`, `integer`, `bigint`, `numeric`, `real`, `double`, `date`, `timestamp`, `text`, `boolean`.
 
-(See [Adding a Scalar Encrypted-Domain Type](./adding-a-scalar-encrypted-domain-type.md) for how the family is generated.) The domains live in the `eql_v3` schema — `DROP SCHEMA eql_v3 CASCADE` removes them — and their extracted index-term types are the self-contained `eql_v3` SEM types (`eql_v3.hmac_256`, `eql_v3.ore_block_256`, `eql_v3.bloom_filter`).
+(See [Adding a Scalar Encrypted-Domain Type](./adding-a-scalar-encrypted-domain-type.md) for how the family is generated.) The domains live in the `public` schema, so they survive `DROP SCHEMA eql_v3 CASCADE` — dropping `eql_v3` removes the operators, extractors, and aggregates but leaves the `public`-typed columns and their data intact. Their extracted index-term types are the self-contained `eql_v3_internal` SEM types (`eql_v3_internal.hmac_256`, `eql_v3_internal.ore_block_256`, `eql_v3_internal.bloom_filter`).
 
 Every scalar generates a storage-only variant plus the query variants its capabilities allow:
 
 | Domain variant                | Index term carried        | Extractor (for indexing) | `=` `<>` | `<` `<=` `>` `>=` | `MIN` / `MAX` | `@>` `<@` |
 | ----------------------------- | ------------------------- | ------------------------ | :------: | :---------------: | :-----------: | :-------: |
-| `eql_v3.<T>`                  | none (storage only)       | —                        |    ❌    |        ❌         |      ❌       |    ❌     |
-| `eql_v3.<T>_eq`               | `hm` (hmac_256)           | `eql_v3.eq_term(col)`    |    ✅    |        ❌         |      ❌       |    ❌     |
-| `eql_v3.<T>_ord` / `_ord_ore` | `ob` (ore_block_256)      | `eql_v3.ord_term(col)`   |    ✅    |        ✅         |      ✅       |    ❌     |
-| `eql_v3.<T>_ord_ope`          | `op` (ope_cllw)           | `eql_v3.ord_ope_term(col)` |  ✅    |        ✅         |      ✅       |    ❌     |
+| `public.<T>`                  | none (storage only)       | —                        |    ❌    |        ❌         |      ❌       |    ❌     |
+| `public.<T>_eq`               | `hm` (hmac_256)           | `eql_v3.eq_term(col)`    |    ✅    |        ❌         |      ❌       |    ❌     |
+| `public.<T>_ord` / `_ord_ore` | `ob` (ore_block_256)      | `eql_v3.ord_term(col)`   |    ✅    |        ✅         |      ✅       |    ❌     |
+| `public.<T>_ord_ope`          | `op` (ope_cllw)           | `eql_v3.ord_ope_term(col)` |  ✅    |        ✅         |      ✅       |    ❌     |
 | `public.text_match`           | `bf` (bloom_filter)       | `eql_v3.match_term(col)` |    ❌    |        ❌         |      ❌       |    ✅\*   |
 | `public.text_search`          | `hm` + `ob` + `bf`        | all three extractors     |    ✅    |        ✅         |      ✅       |    ✅\*   |
 
@@ -34,13 +34,13 @@ Every scalar generates a storage-only variant plus the query variants its capabi
 
 Notes:
 
-- The bare `eql_v3.<T>` variant carries no index term and **blocks every comparison operator** — it is storage / decryption only. Type the column as `_eq` or `_ord` (or cast at the call site, e.g. `col::public.integer_ord`) when you need to query.
+- The bare `public.<T>` variant carries no index term and **blocks every comparison operator** — it is storage / decryption only. Type the column as `_eq` or `_ord` (or cast at the call site, e.g. `col::public.integer_ord`) when you need to query.
 - `_ord` and `_ord_ore` are **twins**: byte-identical surfaces backed by the ORE block term. Pick the name that documents intent ("ordered" vs "ordered via ORE block"); both support the full ordered surface and the `MIN` / `MAX` aggregates.
 - `_ord_ope` exposes the **same ordered surface** backed by the CLLW-OPE term instead: `op` is a hex-encoded, order-preserving ciphertext compared by native bytea ordering after hex-decode (no custom comparison protocol). On `text_ord_ope`, `=` / `<>` route through `hm` (exact HMAC), like `text_ord` — OPE over text is not equality-lossless.
 - `=` / `<>` is the only searchable surface for `_eq`. On `_ord` variants the equality operators are available too (alongside the ordered ones).
 - `boolean` is **storage-only** by design — a two-value column has too little cardinality for any searchable index to be safe, so it ships only `public.boolean` (no `_eq` / `_ord`).
 - `LIKE` / `ILIKE` (`~~` / `~~*`) and the native JSONB operators are **blocked on every scalar domain variant** — they are meaningless on a scalar payload. Text matching is the bloom-filter `@>` on `text_match`, not `LIKE`.
-- `MIN` / `MAX` are exposed only on the ordered variants, as `eql_v3.min(eql_v3.<T>_ord)` / `eql_v3.max(...)` (and the `_ord_ore` twin) — see [EQL Functions Reference](./eql-functions.md#eql_v3min--eql_v3max-per-domain).
+- `MIN` / `MAX` are exposed only on the ordered variants, as `eql_v3.min(public.<T>_ord)` / `eql_v3.max(...)` (and the `_ord_ore` twin) — see [EQL Functions Reference](./eql-functions.md#eql_v3min--eql_v3max-per-domain).
 
 ---
 
@@ -48,7 +48,7 @@ Notes:
 
 A ✅ means the operator resolves on a column typed as that domain variant. A ❌ means the operator is blocked (it raises) for that variant.
 
-| SQL operator              | Meaning                        | `eql_v3.<T>` | `_eq` | `_ord` / `_ord_ore` / `_ord_ope` | `text_match` | `text_search` |
+| SQL operator              | Meaning                        | `public.<T>` | `_eq` | `_ord` / `_ord_ore` / `_ord_ope` | `text_match` | `text_search` |
 | ------------------------- | ------------------------------ | :----------: | :---: | :-----------------: | :----------: | :-----------: |
 | `=`                       | Equality                       |      ❌      |  ✅   |         ✅          |      ❌      |      ✅       |
 | `<>` / `!=`               | Inequality                     |      ❌      |  ✅   |         ✅          |      ❌      |      ✅       |
@@ -77,7 +77,7 @@ This matrix covers higher-level SQL constructs. As above, ✅ requires the colum
 | `WHERE col IN (…)`                   | desugars to `=`                                                                         | `_eq`, `_ord`, `text_search` |
 | `ORDER BY col`                       | meaningful only with an ORE term                                                        | `_ord`, `text_search` |
 | `GROUP BY col` / `DISTINCT`          | needs an equality term                                                                  | `_eq`, `_ord`, `text_search` |
-| `MIN(col)` / `MAX(col)`              | `eql_v3.min(eql_v3.<T>_ord)` / `max` — type the column as `_ord` or cast at the call site (`eql_v3.min(col::public.integer_ord)`) | `_ord` |
+| `MIN(col)` / `MAX(col)`              | `eql_v3.min(public.<T>_ord)` / `max` — type the column as `_ord` or cast at the call site (`eql_v3.min(col::public.integer_ord)`) | `_ord` |
 | `COUNT(col)` / `COUNT(DISTINCT col)` | plain `COUNT(col)` needs no term; `DISTINCT` needs an equality term                     | any / `_eq` for `DISTINCT` |
 | `JOIN … ON lhs.col = rhs.col`        | both sides must share the same keyset and a matching variant                            | `_eq`, `_ord`, `text_search` |
 


### PR DESCRIPTION
## What

Brings the user-facing docs into line with the shipped v3 surface after the public-domain migration (#363). Documentation only — no code changes.

After #363 the surface spans three schemas:
- **`public`** — the encrypted-domain TYPES (`public.<T>`, `public.<T>_eq`, `public.<T>_ord`, `public.text_match`, `public.json`, …), deliberately in `public` so app columns survive EQL uninstall
- **`eql_v3`** — the function/operator API (extractors, comparison wrappers, `min`/`max` aggregates, `version()`)
- **`eql_v3_internal`** — SEM index-term types (`hmac_256`, `ore_block_256`, `bloom_filter`, `ore_cllw`, `ope_cllw`), blockers, aggregate state

Several docs still described the domains/SEM types as living in `eql_v3`, and two reference docs predated the `int4→integer` friendly-name rename and the `Ope` (CLLW-OPE) term.

## Commit 1 — top-level / getting-started docs

- **README.md** — domain types → `public.<T>`; corrected the materially false `DROP SCHEMA eql_v3 CASCADE` claim (public-typed columns survive uninstall); fixed broken doc-validation script paths → `tasks/docs/validate/*.sh`
- **SUPABASE.md** — domain types → `public.*`, `min`/`max` argument types; fixed the false "in the `eql_v3` schema" statement
- **DEVELOPMENT.md** — scalar tree example `bool/` → `boolean/`

## Commit 2 — reference docs

Schema-qualifier fixes:
- **sql-support.md** — domains `public.<T>`; SEM types `eql_v3_internal.*`; corrected the false DROP SCHEMA claim; aggregate arg types
- **eql-functions.md** — extractor RETURN types → `eql_v3_internal.hmac_256`/`ore_block_256`/`bloom_filter`; prose placeholders → `public.<T>`
- **database-indexes.md** — domain-type placeholders → `public.<T>_*`
- **json-support.md** — fixed stale on-page TOC anchor (`#querying-publicjson`)

Codegen currency fixes:
- **adding-a-scalar-encrypted-domain-type.md** — friendly const names (`INTEGER`/`INTEGER_FIXTURES`/`INTEGER_VALUES`); `boolean_*.sql` / `scalars/boolean/`; corrected CLI subcommand list; domains in `public`
- **catalog-driven-architecture.md** — friendly names throughout; **added the missing `Ope` (CLLW-OPE) term axis** to the class diagram, capability table, and 5-/7-domain shape descriptions; real `integer/` file tree; CLI six modes (`list-schemas`); file counts (TS 63, JSON 51); `JSONB` in the catalog family list

`query-performance.md`, `docs/README.md`, `docker/README.md` verified clean (no changes). CLAUDE.md on disk was already correct.

## How this was verified

Delegated per-doc verification agents that checked every schema-qualified type/function/operator name, SQL example, and capability claim against `src/v3/**` and the `crates/eql-*` codegen, then delegated edit agents (one per file group) that re-verified each change against the source before writing. Final repo-wide straggler grep is clean.

## Validation

- `mise run docs:validate:coverage` → ✅ 100%
- `mise run docs:validate:required-tags` → ✅ 0 errors
- (`docs:validate:documented-sql` requires a live Postgres and validates `src/v3/**` SQL, not the markdown here)

## Follow-ups (not in this PR)

- `dbdev/` package artifacts are stale: `dbdev/eql.control` pinned at `2.2.1`, `dbdev/eql--0.0.0.sql` still ships the removed `eql_v2` schema

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated docs to reflect that encrypted scalar domain types now live in `public` and remain available after uninstall.
  * Revised examples, reference tables, and SQL support guidance to use the new `public.<T>` / `public.<T>_*` naming.
  * Clarified encrypted column setup, function references, and index guidance to match the current surface.
  * Refreshed developer and reference docs with updated directory names, validation script paths, and newer catalog examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->