### PR TITLE
ci: register release-alpha coordinator on main (dispatchable)

### DIFF
--- a/.github/workflows/_build-docs.yml
+++ b/.github/workflows/_build-docs.yml
@@ -1,0 +1,85 @@
+name: "Build docs (reusable)"
+
+# Reusable docs build+attach, extracted from release-eql.yml's publish-docs job.
+# The target release already exists: _build-sql.yml creates it for alphas, and
+# a human-created release exists for finals.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref/SHA to build docs from. Empty -> default checkout (github.sha)."
+        required: false
+        type: string
+        default: ""
+      tag:
+        description: "Full release tag. Empty -> build only, no attach."
+        required: false
+        type: string
+        default: ""
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  MISE_VERBOSE: "1"
+
+defaults:
+  run:
+    shell: bash {0}
+
+permissions:
+  contents: write
+
+jobs:
+  publish-docs:
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    name: Build and Publish Documentation
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen
+
+      - name: Generate documentation
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          mise run docs:generate
+          mise run docs:generate:markdown -- "${TAG}"
+          mise run docs:generate:json -- "${TAG}"
+
+      - name: Package documentation
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          mise run docs:package "${TAG}"
+
+      - name: Upload documentation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: eql-docs
+          path: |
+            release/eql-docs-*.zip
+            release/eql-docs-*.tar.gz
+
+      - name: Publish documentation to release
+        if: ${{ inputs.tag != '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            release/eql-docs-*.zip
+            release/eql-docs-*.tar.gz

--- a/.github/workflows/_build-sql.yml
+++ b/.github/workflows/_build-sql.yml
@@ -1,0 +1,114 @@
+name: "Build SQL (reusable)"
+
+# Reusable SQL build+attach, extracted from release-eql.yml's build-and-publish
+# job. Called inline by release-alpha.yml and release-eql.yml so SQL releases
+# have one build path.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref/SHA to build from. Empty -> default checkout (github.sha)."
+        required: false
+        type: string
+        default: ""
+      tag:
+        description: "Full release tag (e.g. eql-3.0.0-alpha.2). Empty -> DEV build, no attach."
+        required: false
+        type: string
+        default: ""
+      attach:
+        description: "Attach the built .sql artefacts to a GitHub Release."
+        required: false
+        type: boolean
+        default: false
+      target_commitish:
+        description: "Non-empty -> create a prerelease at this commit; empty -> attach to the existing release named by tag."
+        required: false
+        type: string
+        default: ""
+      prerelease:
+        description: "Mark the created release as a prerelease (create path only)."
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      MULTITUDES_ACCESS_TOKEN:
+        required: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  MISE_VERBOSE: "1"
+
+defaults:
+  run:
+    shell: bash {0}
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    name: Build EQL
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      - name: Build EQL release
+        # Strip `eql-` so eql_v3.version() reports bare semver. Empty TAG
+        # intentionally falls through build.sh's ${usage_version:-DEV} default.
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          mise run build --version "${TAG#eql-}"
+
+      - name: Upload EQL artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: eql-release
+          path: |
+            release/cipherstash-encrypt.sql
+            release/cipherstash-encrypt-uninstall.sql
+
+      - name: Attach artefacts to existing release
+        if: ${{ inputs.attach && inputs.target_commitish == '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: |
+            release/cipherstash-encrypt.sql
+            release/cipherstash-encrypt-uninstall.sql
+
+      - name: Create prerelease at commit
+        if: ${{ inputs.attach && inputs.target_commitish != '' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          target_commitish: ${{ inputs.target_commitish }}
+          prerelease: ${{ inputs.prerelease }}
+          name: ${{ inputs.tag }}
+          body: "Preview (prerelease) of the standalone eql_v3 surface. See [Unreleased] in CHANGELOG.md."
+          files: |
+            release/cipherstash-encrypt.sql
+            release/cipherstash-encrypt-uninstall.sql
+
+      - name: Notify Multitudes
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          curl --request POST \
+            --fail-with-body \
+            --url "https://api.developer.multitudes.co/deployments" \
+            --header "Content-Type: application/json" \
+            --header "Authorization: ${{ secrets.MULTITUDES_ACCESS_TOKEN }}" \
+            --data '{"commitSha": "${{ github.sha }}", "environmentName":"production"}'

--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,279 @@
+name: "Release alpha (coordinator)"
+
+# CI-native prerelease coordinator for the EQL SQL surface and eql-bindings
+# crate. SQL and docs build in this run; crate publishing is dispatched to
+# release-plz.yml so crates.io Trusted Publishing sees the expected workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "all | eql | bindings"
+        required: true
+        type: choice
+        options: [all, eql, bindings]
+        default: all
+      version:
+        description: "Base SemVer, e.g. 3.0.0"
+        required: false
+        type: string
+        default: "3.0.0"
+      channel:
+        description: "alpha | beta | rc"
+        required: false
+        type: choice
+        options: [alpha, beta, rc]
+        default: alpha
+      pre:
+        description: "Exact identity (e.g. 3.0.0-alpha.2), bypassing N derivation"
+        required: false
+        type: string
+        default: ""
+      dry_run:
+        description: "Resolve + verify + print plan; mutate nothing"
+        required: false
+        type: boolean
+        default: false
+      dispatch_id:
+        description: "Client-generated correlation id. Leave blank for manual dispatch."
+        required: false
+        type: string
+        default: ""
+
+run-name: >-
+  release-alpha ${{ inputs.target }} ${{ inputs.pre != '' && inputs.pre || format('{0}-{1}', inputs.version, inputs.channel) }}${{ inputs.dry_run && ' [dry-run]' || '' }} [${{ inputs.dispatch_id }}]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-alpha
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  MISE_VERBOSE: "1"
+
+defaults:
+  run:
+    shell: bash {0}
+
+jobs:
+  resolve:
+    name: Resolve identity + verify
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    timeout-minutes: 15
+    outputs:
+      identity: ${{ steps.derive.outputs.identity }}
+      sql_tag: ${{ steps.derive.outputs.sql_tag }}
+      crate_tag: ${{ steps.derive.outputs.crate_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Fetch all tags
+        run: git fetch --tags --force
+
+      - name: Resolve identity + guards
+        id: derive
+        env:
+          TARGET: ${{ inputs.target }}
+          VERSION: ${{ inputs.version }}
+          CHANNEL: ${{ inputs.channel }}
+          PRE: ${{ inputs.pre }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+        run: .github/scripts/release-alpha-resolve.sh
+
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      - name: Verify drift gates (types:check + codegen:parity)
+        run: |
+          set -euo pipefail
+          mise run types:check
+          mise run codegen:parity
+
+      - name: Print plan
+        env:
+          TARGET: ${{ inputs.target }}
+          DRY: ${{ inputs.dry_run }}
+          IDENTITY: ${{ steps.derive.outputs.identity }}
+          SQL_TAG: ${{ steps.derive.outputs.sql_tag }}
+          CRATE_TAG: ${{ steps.derive.outputs.crate_tag }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Release plan"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| target | ${TARGET} |"
+            echo "| identity | ${IDENTITY} |"
+            echo "| sql_tag | ${SQL_TAG} |"
+            echo "| crate_tag | ${CRATE_TAG} |"
+            echo "| ref | ${REF_NAME} @ ${SHA} |"
+            echo "| dry_run | ${DRY} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  pin:
+    name: Pin crate version (commit S)
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    needs: resolve
+    if: ${{ !inputs.dry_run && (inputs.target == 'all' || inputs.target == 'bindings') }}
+    permissions:
+      contents: write
+    timeout-minutes: 15
+    outputs:
+      commit_sha: ${{ steps.commit.outputs.commit_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          # Pin from the dispatch SHA that resolve validated. Pushing HEAD back
+          # to the branch will fail if the branch advanced meanwhile.
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v7
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - uses: jdx/mise-action@v3
+        with:
+          version: 2026.4.0
+          install: true
+          cache: true
+
+      - name: Install release-plz CLI
+        run: cargo binstall --no-confirm release-plz
+
+      - name: Pin + commit + push (commit S)
+        id: commit
+        env:
+          IDENTITY: ${{ needs.resolve.outputs.identity }}
+          BRANCH: ${{ github.ref_name }}
+          GH_TOKEN: ${{ github.token }}
+        run: .github/scripts/release-alpha-pin-bindings.sh
+
+      - name: Verify pin commit signature
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ steps.commit.outputs.commit_sha }}
+        run: .github/scripts/release-alpha-verify-commit-signature.sh "$COMMIT_SHA"
+
+  build-sql:
+    name: Build + release SQL (in-run)
+    needs: [resolve, pin]
+    if: >-
+      ${{ !cancelled() && !inputs.dry_run
+          && (inputs.target == 'all' || inputs.target == 'eql')
+          && needs.resolve.result == 'success'
+          && (needs.pin.result == 'success' || needs.pin.result == 'skipped') }}
+    permissions:
+      contents: write
+    secrets:
+      MULTITUDES_ACCESS_TOKEN: ${{ secrets.MULTITUDES_ACCESS_TOKEN }}
+    uses: ./.github/workflows/_build-sql.yml
+    with:
+      ref: ${{ inputs.target == 'all' && needs.pin.outputs.commit_sha || '' }}
+      tag: ${{ needs.resolve.outputs.sql_tag }}
+      attach: true
+      target_commitish: ${{ inputs.target == 'all' && needs.pin.outputs.commit_sha || github.sha }}
+      prerelease: true
+
+  build-docs:
+    name: Build + attach docs (in-run)
+    needs: [resolve, pin, build-sql]
+    if: >-
+      ${{ !cancelled() && !inputs.dry_run
+          && (inputs.target == 'all' || inputs.target == 'eql')
+          && needs.build-sql.result == 'success' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/_build-docs.yml
+    with:
+      ref: ${{ inputs.target == 'all' && needs.pin.outputs.commit_sha || github.sha }}
+      tag: ${{ needs.resolve.outputs.sql_tag }}
+
+  crate-publish:
+    name: Dispatch crate publish (release-plz.yml)
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    needs: [resolve, pin, build-sql, build-docs]
+    if: >-
+      ${{ !cancelled() && !inputs.dry_run
+          && (inputs.target == 'all' || inputs.target == 'bindings')
+          && needs.pin.result == 'success'
+          && (needs.build-sql.result == 'success' || needs.build-sql.result == 'skipped')
+          && (needs.build-docs.result == 'success' || needs.build-docs.result == 'skipped') }}
+    timeout-minutes: 10
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch release-plz.yml against the pinned commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SQL_TAG: ${{ needs.resolve.outputs.sql_tag }}
+          BRANCH: ${{ github.ref_name }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          if [[ "$TARGET" == "all" ]]; then
+            ref="$SQL_TAG"
+          else
+            ref="$BRANCH"
+          fi
+          echo "Dispatching release-plz.yml --ref ${ref}"
+          gh workflow run release-plz.yml --ref "$ref"
+          {
+            echo "## Crate publish dispatch accepted"
+            echo ""
+            echo "Crate publish DISPATCHED against \`${ref}\`."
+            echo "Verify the separate \`release-plz.yml\` run reaches a terminal success state before treating the crate as published."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  summary:
+    name: Summary
+    runs-on: blacksmith-16vcpu-ubuntu-2204
+    needs: [resolve, pin, build-sql, build-docs, crate-publish]
+    if: always()
+    steps:
+      - name: Emit run summary
+        env:
+          TARGET: ${{ inputs.target }}
+          DRY: ${{ inputs.dry_run }}
+          IDENTITY: ${{ needs.resolve.outputs.identity }}
+          SQL_TAG: ${{ needs.resolve.outputs.sql_tag }}
+          CRATE_TAG: ${{ needs.resolve.outputs.crate_tag }}
+          RESOLVE_RESULT: ${{ needs.resolve.result }}
+          PIN_RESULT: ${{ needs.pin.result }}
+          BUILD_SQL_RESULT: ${{ needs.build-sql.result }}
+          BUILD_DOCS_RESULT: ${{ needs.build-docs.result }}
+          CRATE_PUBLISH_RESULT: ${{ needs.crate-publish.result }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## release-alpha result"
+            echo ""
+            echo "- target: \`${TARGET}\` (dry_run=${DRY})"
+            echo "- identity: \`${IDENTITY}\`"
+            echo "- sql_tag: \`${SQL_TAG}\`"
+            echo "- crate_tag: \`${CRATE_TAG}\`"
+            echo "- resolve: ${RESOLVE_RESULT} | pin: ${PIN_RESULT} | build-sql: ${BUILD_SQL_RESULT} | build-docs: ${BUILD_DOCS_RESULT} | crate-publish-dispatch: ${CRATE_PUBLISH_RESULT}"
+            echo ""
+            echo "Coordinator run: ${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+            echo "Crate publish is only DISPATCHED by this coordinator. Verify the separate release-plz.yml run before treating the crate publish as successful."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Unblocks cutting a **v3 alpha before #314 (`eql_v3 → main`) merges**.

## Problem

`mise run release:eql` dispatches the `release-alpha.yml` coordinator with `--ref eql_v3`, but it fails:

```
HTTP 404: workflow release-alpha.yml not found on the default branch
```

GitHub only lets you dispatch a `workflow_dispatch` workflow that is **registered on the default branch**. `release-alpha.yml` (and its reusable `_build-sql.yml` / `_build-docs.yml`) currently live only on `eql_v3`, so there's nothing to dispatch from `main`.

## Fix

Add the three workflow files to `main`, **verbatim from `eql_v3`**:

- `.github/workflows/release-alpha.yml` — the coordinator (registered so it's dispatchable)
- `.github/workflows/_build-sql.yml` — reusable, `workflow_call`
- `.github/workflows/_build-docs.yml` — reusable, `workflow_call` (runs `docs:generate:json`, so the docs tarball carries `json/eql-manifest.json`)

All three are `workflow_dispatch` / `workflow_call` only — **inert on `main` until invoked**.

## Why this is safe / correct

When dispatched with `--ref eql_v3`, the *run* executes at that ref: the checkout, the `.github/scripts/release-alpha-*.sh` scripts, the mise tasks (`types:check`, `codegen:parity`, `docs:generate:json`), and the `uses: ./_build-*.yml` reusable workflows all resolve from `eql_v3`. `main` only needs the top-level workflow **registered** for the dispatch to be accepted. The two reusables are carried along so `uses: ./` resolves regardless of how GitHub picks the ref for the run.

The reusable builds check out their `ref` input (the dispatch SHA / tag), so even their copy on `main` executes `eql_v3` code — nothing v2-era on `main` is used.

## Scope

- No trigger runs on push/PR to `main` (dispatch/call only).
- `target=eql` (what `mise run release:eql` uses) does **not** dispatch `release-plz.yml`, so it isn't needed here.
- **Temporary:** superseded when **#314** merges and promotes these files to `main` as part of the v3 line. If they've drifted on `eql_v3` by then, the merge reconciles them.

## After merge

```bash
mise run release:eql --ref eql_v3 --dry-run   # resolves eql-3.0.0-alpha.3, verifies drift gates
mise run release:eql --ref eql_v3             # cuts it; attaches eql-docs-* with json/eql-manifest.json
```

https://claude.ai/code/session_01CqDNqLSEEkCi7xAJFq7HJA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable workflows for building documentation and SQL artifacts, including support for attaching outputs to releases or publishing prereleases.
  * Added a new alpha release workflow with manual triggering, dry-run support, and selectable targets for SQL, bindings, or both.
  * Improved release coordination by generating a release plan, running validation checks, and publishing a consolidated summary of each run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->