### PR TITLE
ci: register release-plz.yml on the default branch (dispatch stub)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,25 @@
+name: "Release eql-bindings (crates.io)"
+
+# REGISTRATION STUB — the real workflow lives on the eql_v3 release line.
+#
+# GitHub only registers (and allows dispatching) workflows whose file exists on
+# the DEFAULT branch. workflow_dispatch then executes the file at the
+# *dispatched ref*, so release.yml on eql_v3 can dispatch this workflow against
+# an eql-<version> tag and run that tag's full publish job. Without this stub
+# the workflow has no ID and every dispatch 404s.
+#
+# Replace with the full workflow when the eql_v3 release line merges to main
+# (the production crate publish triggers on push to main).
+
+on:
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  noop:
+    name: "Registration stub (real job runs at the dispatched ref)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - run: echo "release-plz.yml stub on main — dispatch against an eql-<version> tag or eql_v3 to run the real publish job"


### PR DESCRIPTION
Fixes the crate-publish leg of the eql_v3 prerelease flow.

**Problem:** GitHub only registers — and allows `workflow_dispatch` of — workflows whose file exists on the **default branch**. `release-plz.yml` lives only on `eql_v3` and has never run, so it has no workflow ID; `release.yml`'s 'Dispatch prerelease Rust publish' job 404s (`workflow release-plz.yml not found on the default branch`), and the eql-3.0.0-alpha.3 crate publish could not be dispatched.

**Fix:** a registration stub at the same path on `main`. `workflow_dispatch` executes the workflow file **at the dispatched ref**, so the stub only provides registration — the real publish job runs from the `eql-<version>` tag that `release.yml` dispatches against. The stub itself is inert (`permissions: {}`, no-op job, no push trigger — deliberately, since `main` has no `crates/` workspace for release-plz to operate on yet).

Replace with the full workflow when the eql_v3 release line merges to `main` (the production crate publish design triggers on push to main and requires the real file there).

Related follow-up (registry-side, not in this PR): crates.io Trusted Publishing for `eql-bindings` (workflow `release-plz.yml`) and npm Trusted Publishing for `@cipherstash/eql` (workflow `release.yml`) both appear unconfigured — every existing version of each package was published manually. The dispatch will reach release-plz but the cargo publish will fail auth until that's set up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a workflow stub so the release process is registered and can be manually triggered from the default branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->