### PR TITLE
fix(docs): suppress Doxygen auto-linking of `text` in jsonb selector @warning

### DIFF
--- a/src/v3/jsonb/operators.sql
+++ b/src/v3/jsonb/operators.sql
@@ -18,8 +18,8 @@
 --! index on `eql_v3.eq_term(col -> 'sel')`.
 --!
 --! @warning The selector operand MUST carry a known type — a text-typed
---!   parameter (`$1`, the Proxy interface) or an explicit cast (`col -> 'sel'::text`).
---!   A bare untyped literal (`col -> 'sel'`) resolves to the NATIVE `jsonb -> text`
+--!   parameter (`$1`, the Proxy interface) or an explicit cast (`col -> 'sel'::%text`).
+--!   A bare untyped literal (`col -> 'sel'`) resolves to the NATIVE `jsonb -> %text`
 --!   operator and silently returns native jsonb semantics (a root-key lookup,
 --!   typically NULL), NOT this operator: PostgreSQL reduces the `public.json`
 --!   domain to its base type `jsonb` when resolving an unknown-typed RHS, and the


### PR DESCRIPTION
Fixes https://github.com/cipherstash/encrypt-query-language/issues/384

## Problem

Doxygen auto-links the bare word `text` (it collides with a documented symbol) into a cross-reference **inside inline code** in the jsonb selector operator's `@warning`:

```xml
<computeroutput>col -&gt; &apos;sel&apos;<ref refid="lints_8sql_...">text</ref></computeroutput>
```

A `<ref>` nested in `<computeroutput>` renders to an **unbalanced `<tt>`** in `API.md`, which broke the cipherstash/docs MDX build on **eql-3.0.0-alpha.3** (`index.mdx:2153: Expected a closing tag for <tt>`). The `::` was dropped too, so the cast read `'sel'text`.

## Fix

Prefix the two `text` occurrences with Doxygen's `%` no-autolink marker (`::%text`, `-> %text`) in `src/v3/jsonb/operators.sql`. The `%` is consumed by Doxygen (not rendered).

## Verification

Ran `doxygen` on the changed source:
- The nested `<ref>` is gone.
- `col -> 'sel'::text` renders as clean, balanced inline code (the `::` is preserved).

Note: my local doxygen is 1.15.0, which masks the `<tt>` symptom; please confirm against the CI doxygen version. The fix removes the version-independent trigger (the nested `<ref>`), so it resolves the break on any version.

## Related

- Downstream safety net: cipherstash/docs#52 (defensively strips `<tt>` in the docs generator).
- Alternative root fix discussed in the issue: `AUTOLINK_SUPPORT = NO` in the Doxyfile.