### PR TITLE
ci(release-plz): send a User-Agent to the crates.io API

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -87,7 +87,10 @@ jobs:
         run: |
           set -euo pipefail
           cargo_version="$(grep -m1 '^version = ' crates/eql-bindings/Cargo.toml | cut -d'"' -f2)"
-          published="$(curl -fsSL --retry 3 "https://crates.io/api/v1/crates/eql-bindings/versions" | jq -r '.versions[].num' | grep -Fx "$cargo_version" || true)"
+          # crates.io rejects curl's default User-Agent with a 403. Without an
+          # explicit UA the request always fails, `|| true` swallows it, and the
+          # no-op short-circuit below is unreachable.
+          published="$(curl -fsSL --retry 3 -H "User-Agent: cipherstash-eql-release (https://github.com/cipherstash/encrypt-query-language)" "https://crates.io/api/v1/crates/eql-bindings/versions" | jq -r '.versions[].num' | grep -Fx "$cargo_version" || true)"
           if [[ -n "$published" ]]; then
             echo "eql-bindings@${cargo_version} is already on crates.io; this run is a publish no-op — skipping the bundled-SQL guard"
             exit 0


### PR DESCRIPTION
## What

Send an explicit `User-Agent` header on the crates.io API request in `release-plz.yml`'s "Verify bundled SQL matches the crate version" step.

## Why

crates.io answers curl's default User-Agent with a **403**. The probe that asks "is this version already published?" therefore never returned a version:

```
Verify bundled SQL matches the crate version   curl: (22) The requested URL returned error: 403
```

`|| true` swallowed the failure, `published` was always empty, and the no-op short-circuit immediately below it was **unreachable**. Every routine push to `main` ran the full bundled-SQL guard instead of skipping it.

This was never *unsafe* — the step is deliberately written so that a crates.io API failure fails towards enforcing the guard, never towards skipping it — but the short-circuit has never once worked as documented.

## Verification

I extracted the step's `run` block straight out of the YAML and executed it against the real tree, so both branches are exercised rather than assumed:

- **Current tree** (`Cargo.toml` = `3.0.0-alpha.4`, already on crates.io) → `eql-bindings@3.0.0-alpha.4 is already on crates.io; this run is a publish no-op — skipping the bundled-SQL guard`, exit 0. The short-circuit engages for the first time.
- **The upcoming `3.0.0` run** → `3.0.0` is not on crates.io, so `published` is empty and the guard is **enforced**, exactly as intended.

Directly against the API: default UA → `403`, explicit UA → `200`.

This is the only `crates.io/api` caller in the repo.

## Changeset

None — CI/tooling-only change, per `CLAUDE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the release check so it can reliably detect when the current package version is already published.
  * Added a custom request header to avoid failed version checks caused by the default network request behavior.
  * Kept the existing retry and version comparison flow unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->