### PR TITLE
ci(known-failures): close four fail-open / false-positive paths (CIP-3488)

### DIFF
--- a/tasks/test/known-failures.sh
+++ b/tasks/test/known-failures.sh
@@ -14,6 +14,10 @@
 # you cannot keep suppressing it once the bug is closed.
 #
 # Needs `gh` authenticated (CI: GITHUB_TOKEN). Read-only.
+#
+# Portability: targets bash 3.2 (stock macOS /bin/bash), since mise.toml invokes
+# this as `bash tasks/test/known-failures.sh`. No `mapfile`, no other bash-4
+# features.
 set -euo pipefail
 
 EQL_ROOT="${EQL_ROOT:-$(git rev-parse --show-toplevel)}"
@@ -25,17 +29,89 @@ REGISTRY="${EQL_ROOT}/tests/sqlx/src/known_failure.rs"
 repo=$(sed -n 's/^pub const KNOWN_FAILURE_REPO: &str = "\(.*\)";$/\1/p' "$REGISTRY")
 [ -n "$repo" ] || { echo "could not read KNOWN_FAILURE_REPO from $REGISTRY" >&2; exit 2; }
 
-# Every `pub const ISSUE_<NAME>: u64 = <n>;` in the registry.
-mapfile -t entries < <(
-  sed -n 's/^pub const \(ISSUE_[A-Z0-9_]*\): u64 = \([0-9]*\);$/\1 \2/p' "$REGISTRY"
-)
+# Count declarations with a LOOSE matcher (anything that reads as an `ISSUE_*`
+# constant), independently of the strict parse below. If the strict parse
+# recovers FEWER rows than were declared, the format drifted (a `u32`, a renamed
+# type, a malformed line) and the strict regex would silently skip markers. A
+# gate that parses zero rows and exits 0 is the exact fail-open this check exists
+# to prevent, so a declared-vs-parsed mismatch is a hard error, never a pass.
+declared=$(grep -cE '^[[:space:]]*pub const ISSUE_[A-Za-z0-9_]+[[:space:]]*:' "$REGISTRY" || true)
 
-if [ "${#entries[@]}" -eq 0 ]; then
+# Strict parse: `pub const ISSUE_<NAME>: u64 = <n>;` → "<NAME> <n>". Tolerant of
+# leading indentation, a trailing line comment, and `_` digit separators so that
+# benign formatting is not mistaken for drift; the type must still be `u64`.
+# bash 3.2-safe accumulation (no `mapfile`): a while-read loop over a process
+# substitution runs in the current shell, so the array persists after the loop.
+entries=()
+while IFS= read -r line; do
+  entries+=("$line")
+done < <(
+  sed -n -E \
+    's/^[[:space:]]*pub const (ISSUE_[A-Z0-9_]+)[[:space:]]*:[[:space:]]*u64[[:space:]]*=[[:space:]]*([0-9_]+)[[:space:]]*;.*$/\1 \2/p' \
+    "$REGISTRY"
+)
+parsed=${#entries[@]}
+
+if [ "$declared" -ne "$parsed" ]; then
+  echo "known-failure gate: parsed ${parsed} of ${declared} declared ISSUE_ constant(s)." >&2
+  echo '    The strict `pub const ISSUE_<NAME>: u64 = <n>;` parser skipped a declaration —' >&2
+  echo "    a format change (wrong type, malformed line) would let a marker slip past this" >&2
+  echo "    gate unverified. Fix the declaration or this parser; refusing to run." >&2
+  exit 2
+fi
+
+if [ "$parsed" -eq 0 ]; then
   echo "==> no known-failure markers registered — nothing to verify."
   exit 0
 fi
 
-echo "==> verifying ${#entries[@]} known-failure marker(s) against ${repo}"
+echo "==> verifying ${parsed} known-failure marker(s) against ${repo}"
+
+# Classify one issue number via the REST issues endpoint. Prints exactly one of
+#   OPEN | CLOSED | PULL_REQUEST | NOT_FOUND | ERROR:<detail>
+# on stdout, and never itself exits non-zero (the caller decides pass/fail).
+#
+# Using `gh api repos/<repo>/issues/<n>` — rather than `gh issue view` — closes
+# two review findings:
+#   * T3: a TRANSIENT failure (5xx, rate-limit, unauthenticated, DNS) is
+#     distinguishable from a genuine 404. `gh api` reports a missing issue as
+#     `(HTTP 404)` and everything else with a different message, so a network
+#     blip no longer masquerades as "issue missing" (nor the reverse).
+#   * T15: issues and PRs share a number space and `gh issue view` happily
+#     resolves a PR number. The REST issues object carries a `pull_request` key
+#     iff the number is a PR, so PRs are rejected instead of passing as issues.
+classify_number() {
+  number="$1"
+  err_file=$(mktemp)
+  # On HTTP 200 the bundled `--jq` prints "<state>\t<is_pr>"; on any HTTP/network
+  # error `gh` exits non-zero and writes the reason to stderr (jq is not applied).
+  if out=$(gh api "repos/${repo}/issues/${number}" \
+             --jq '"\(.state)\t\(has("pull_request"))"' 2>"$err_file"); then
+    rm -f "$err_file"
+    state="${out%%$'\t'*}"
+    is_pr="${out##*$'\t'}"
+    if [ "$is_pr" = "true" ]; then
+      echo "PULL_REQUEST"
+      return 0
+    fi
+    case "$state" in
+      open)   echo "OPEN" ;;
+      closed) echo "CLOSED" ;;
+      *)      echo "ERROR:unexpected issue state '${state}'" ;;
+    esac
+    return 0
+  fi
+
+  err=$(cat "$err_file"); rm -f "$err_file"
+  # A definitive 404 is a genuinely missing issue; anything else is transient
+  # infrastructure and must NOT read as "missing".
+  if printf '%s' "$err" | grep -qi 'HTTP 404'; then
+    echo "NOT_FOUND"
+  else
+    # Collapse to a single line so the caller's diagnostic stays readable.
+    echo "ERROR:$(printf '%s' "$err" | tr '\n' ' ' | sed 's/[[:space:]]\{1,\}/ /g')"
+  fi
+}
 
 # A marker whose constant is never referenced by a test is dead weight: the bug
 # may be long fixed and nobody noticed. Catch that too.
@@ -43,11 +119,12 @@ fail=0
 for entry in "${entries[@]}"; do
   name=${entry%% *}
   number=${entry##* }
+  number=${number//_/}   # `1_000` (Rust literal) → 1000 for the API path
 
-  # `grep` exits 1 when it matches nothing — which is exactly the case this
-  # check exists to report. Under `set -e` + `pipefail` that status propagates
-  # out of the pipeline and kills the script here, before the diagnostic below
-  # can print. Swallow only grep's status; `wc` still counts the (empty) input.
+  # `grep` exits 1 when it matches nothing — which is exactly the case this check
+  # exists to report. Under `set -e` + `pipefail` that status propagates out of
+  # the pipeline and kills the script here, before the diagnostic below can
+  # print. Swallow only grep's status; `wc` still counts the (empty) input.
   refs=$( { grep -rl --include='*.rs' -- "$name" "${EQL_ROOT}/tests/sqlx/tests" 2>/dev/null || true; } | wc -l | tr -d ' ')
   if [ "$refs" -eq 0 ]; then
     echo "  ✗ ${name} (#${number}) is registered but referenced by no test — remove it" >&2
@@ -55,8 +132,8 @@ for entry in "${entries[@]}"; do
     continue
   fi
 
-  state=$(gh issue view "$number" --repo "$repo" --json state -q .state 2>/dev/null || echo "MISSING")
-  case "$state" in
+  result=$(classify_number "$number")
+  case "$result" in
     OPEN)
       echo "  ✓ ${name} → ${repo}#${number} is OPEN (${refs} test ref(s))"
       ;;
@@ -66,9 +143,24 @@ for entry in "${entries[@]}"; do
       echo "    or it was closed in error (reopen it)." >&2
       fail=1
       ;;
-    *)
-      echo "  ✗ ${name} → ${repo}#${number} could not be read (state=${state})." >&2
+    PULL_REQUEST)
+      echo "  ✗ ${name} → ${repo}#${number} is a PULL REQUEST, not an issue." >&2
+      echo "    Issues and PRs share a number space; point the marker at the tracking issue." >&2
+      fail=1
+      ;;
+    NOT_FOUND)
+      echo "  ✗ ${name} → ${repo}#${number} does not exist." >&2
       echo "    A known-failure marker must name a real issue." >&2
+      fail=1
+      ;;
+    ERROR:*)
+      echo "  ✗ ${name} → ${repo}#${number} could not be verified (${result#ERROR:})." >&2
+      echo "    This looks like a transient GitHub/network error, not a missing issue —" >&2
+      echo "    re-run the gate; if it persists, check gh auth / GitHub status." >&2
+      fail=1
+      ;;
+    *)
+      echo "  ✗ ${name} → ${repo}#${number}: unexpected classifier result '${result}'." >&2
       fail=1
       ;;
   esac


### PR DESCRIPTION
Closes [CIP-3488](https://linear.app/cipherstash/issue/CIP-3488).

`tasks/test/known-failures.sh` — the CI gate cipherstash/encrypt-query-language#389 introduced — had four independent defects that let it pass a broken state. All four were raised in review on cipherstash/encrypt-query-language#389, none addressed before merge, all still live on `main`. This gate exists to stop known-failure registrations from silently rotting, but in its current form it can report success while doing nothing at all — the exact failure mode it was built to prevent.

### Fixes

* **T14 — fails open (blocking).** The registry parser was fully anchored and hardcoded `u64`: any deviation (`u32`, indentation, a trailing comment, `1_000`) parsed zero rows, printed "nothing to verify", and `exit 0`. Now: the strict `pub const ISSUE_<NAME>: u64 = <n>;` parse tolerates indentation / trailing line comments / `_` digit separators, and the declaration count is taken independently with a loose matcher — a **declared-vs-parsed mismatch is a hard error (**`exit 2`**)**, so format drift can never silently skip a marker.
* **T3 — transient failure read as "issue missing" (blocking).** Replaced `gh issue view … 2>/dev/null || echo "MISSING"` (which conflated 5xx / rate-limit / auth / DNS with a real 404) with `gh api repos/<repo>/issues/<n>`: a genuine `(HTTP 404)` classifies as `NOT_FOUND`, everything else as a **distinct transient** `ERROR` with a "re-run the gate" hint. A network blip no longer red-lights `ci-required` under the wrong message.
* **T15 — PR numbers pass as issues.** Issues and PRs share a number space and `gh issue view` resolves both. The REST issues object carries a `pull_request` key iff the number is a PR, so **PR numbers are now rejected** instead of validating as open issues.
* **T16 — not portable.** Replaced `mapfile` (bash 4+) with a **bash 3.2-safe** `while read` **loop** — `mise.toml` invokes this as `bash tasks/test/known-failures.sh` and stock macOS `/bin/bash` is 3.2.

(T2, the `set -euo pipefail` dead-code branch, was already fixed on `main` via a `|| true` guard — not included.)

### Verification

Tested end-to-end against the live registry and crafted fixtures:

<!-- linear:table-colwidths:400,400 -->
| Scenario | Result |
| -- | -- |
| real registry (issue cipherstash/encrypt-query-language#387) | `OPEN`, gate OK |
| `u32` drift (declared 1, parsed 0) | **exit 2**, hard error |
| PR cipherstash/encrypt-query-language#399 as an `ISSUE_*` | **rejected** as PULL REQUEST |
| missing [#99999999](<https://github.com/cipherstash/encrypt-query-language/issues/99999999>) | `NOT_FOUND` — "does not exist" |
| `3_87` + indentation + `// comment` | parsed **387**, OPEN (tolerant) |

Also confirmed clean under stock `/bin/bash` 3.2.57 (T16). CI-only change, no changeset (per CLAUDE.md exclusions).

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of known-failure markers to detect formatting inconsistencies.
  * Added clearer diagnostics for open, closed, missing, and invalid issue references.
  * Prevented pull requests from being incorrectly treated as issues.
  * Improved handling of verification and connectivity errors.
  * Retained checks for unused known-failure markers.