### PR TITLE
test(eql_v3): close CLLW-OPE migration coverage gaps (CIP-3491)

### DIFF
--- a/tests/sqlx/tests/encrypted_domain/float_special.rs
+++ b/tests/sqlx/tests/encrypted_domain/float_special.rs
@@ -25,20 +25,49 @@
 
 use anyhow::Result;
 use eql_tests::fixtures::cipherstash::encrypt_store;
+use eql_tests::fixtures::eql_plaintext::EqlPlaintext;
 use eql_tests::fixtures::index_kind::IndexKind;
 use eql_tests::known_failure;
 use eql_tests::known_failure::ISSUE_FLOAT_SIGNED_ZERO_EQ;
 use eql_tests::property::{connect_pool, ensure_eql_installed};
-use eql_tests::scalar_domains::F8;
+use eql_tests::scalar_domains::{ScalarType, Variant, F4, F8};
 use sqlx::PgPool;
 
-/// Encrypt one batch of f64 special values into payload JSON strings, one
+/// The signed-zero pair (`-0.0`, `+0.0`) for a float scalar. `SignedScalar`
+/// already yields `+0.0` via `origin()`, but not `-0.0`, so this local trait
+/// supplies both and lets the ±0.0 tests run over `real` (F4) as well as
+/// `double` (F8) — they share the same crypto path, so both must be pinned.
+trait SignedZeroPair: EqlPlaintext + ScalarType {
+    fn neg_zero() -> Self;
+    fn pos_zero() -> Self;
+}
+
+impl SignedZeroPair for F4 {
+    fn neg_zero() -> Self {
+        F4(-0.0)
+    }
+    fn pos_zero() -> Self {
+        F4(0.0)
+    }
+}
+
+impl SignedZeroPair for F8 {
+    fn neg_zero() -> Self {
+        F8(-0.0)
+    }
+    fn pos_zero() -> Self {
+        F8(0.0)
+    }
+}
+
+/// Encrypt one batch of float special values into payload JSON strings, one
 /// ZeroKMS round trip. Mirrors `e2e_oracle::encrypt_rows` but returns only the
 /// payloads (these tests key on position, not plaintext). `encrypt_store`
 /// encrypts through cipherstash-client directly — it needs no `PgPool` — and
 /// returns v3-envelope payloads (converted via eql_bindings::from_v2), so
-/// the casts below satisfy the `v = '3'` domain CHECKs.
-async fn encrypt_specials(values: &[F8]) -> Result<Vec<String>> {
+/// the casts below satisfy the `v = '3'` domain CHECKs. Generic over the float
+/// scalar so the ±0.0 tests can encrypt `real` (F4) and `double` (F8) alike.
+async fn encrypt_specials<T: EqlPlaintext>(values: &[T]) -> Result<Vec<String>> {
     let payloads = encrypt_store(
         "float_special",
         "payload",
@@ -50,6 +79,20 @@ async fn encrypt_specials(values: &[F8]) -> Result<Vec<String>> {
     )
     .await?;
     Ok(payloads.into_iter().map(|p| p.to_string()).collect())
+}
+
+/// Encrypt the ±0.0 pair for the float scalar `T` in one ZeroKMS round trip,
+/// returning `[payload(-0.0), payload(+0.0)]`. Shared by every ±0.0 test so each
+/// runs identically over `real` and `double`.
+async fn signed_zero_payloads<T: SignedZeroPair>() -> Result<Vec<String>> {
+    encrypt_specials(&[T::neg_zero(), T::pos_zero()]).await
+}
+
+/// `T`'s SQL domain for `variant` (e.g. `public.eql_v3_real_ord` /
+/// `public.eql_v3_double_ord`). Lets the generic ±0.0 helpers name the right
+/// per-type domain in both the cast and the failure message.
+fn domain<T: ScalarType>(variant: Variant) -> String {
+    T::sql_domain(variant)
 }
 
 /// Cast a payload literal to `public.eql_v3_double` and read it back, proving the domain
@@ -68,17 +111,11 @@ async fn cast_passes_check(pool: &PgPool, payload: &str) -> Result<()> {
 }
 
 /// Compare two payloads under an operator on `public.eql_v3_double_ord` — the default
-/// ordering domain, backed by CLLW-OPE (`op`). Used to pin the discovered
-/// NaN/±0/±Inf outcomes.
+/// ordering domain, backed by CLLW-OPE (`op`). Used by the NaN/±Inf pins, which
+/// stay `double`-only (the ±0.0 pins parameterise over `real`/`double` via
+/// `cmp_on` + `domain::<T>` instead).
 async fn ord_cmp(pool: &PgPool, a: &str, op: &str, b: &str) -> Result<bool> {
     cmp_on(pool, "public.eql_v3_double_ord", a, op, b).await
-}
-
-/// The same comparison on `public.eql_v3_double_ord_ore` — the block-ORE ordering
-/// domain. Kept distinct from [`ord_cmp`] because the two SEMs do not agree on
-/// `-0.0` vs `+0.0` (see the module doc).
-async fn ord_ore_cmp(pool: &PgPool, a: &str, op: &str, b: &str) -> Result<bool> {
-    cmp_on(pool, "public.eql_v3_double_ord_ore", a, op, b).await
 }
 
 async fn cmp_on(pool: &PgPool, d: &str, a: &str, op: &str, b: &str) -> Result<bool> {
@@ -135,21 +172,46 @@ async fn two_encryptions_of_same_nan_bits_compare_equal() -> Result<()> {
     Ok(())
 }
 
+/// Generic body of `negative_zero_and_positive_zero_share_ore_order`, run per
+/// float type: block-ORE orders `-0.0` and `+0.0` equal on `T`'s `_ord_ore`.
+async fn share_ore_order<T: SignedZeroPair>(pool: &PgPool) -> Result<()> {
+    let d = domain::<T>(Variant::OrdOre);
+    let p = signed_zero_payloads::<T>().await?;
+    anyhow::ensure!(
+        !cmp_on(pool, &d, &p[0], "<", &p[1]).await?,
+        "-0.0 not < +0.0 under block-ORE ({d})"
+    );
+    anyhow::ensure!(
+        !cmp_on(pool, &d, &p[1], "<", &p[0]).await?,
+        "+0.0 not < -0.0 under block-ORE ({d})"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn negative_zero_and_positive_zero_share_ore_order() -> Result<()> {
     // Block-ORE rides the `orderable-bytes` encoder, which canonicalizes
     // -0.0 -> +0.0 before encoding, so `_ord_ore` orders them equal — matching
     // IEEE (-0.0 == 0.0). Contrast `negative_zero_orders_below_positive_zero_
-    // under_ope`: the OPE term does NOT canonicalize.
+    // under_ope`: the OPE term does NOT canonicalize. `real` and `double` share
+    // the encoder, so both are pinned.
     let pool = setup().await?;
-    let p = encrypt_specials(&[F8(-0.0), F8(0.0)]).await?;
-    assert!(
-        !ord_ore_cmp(&pool, &p[0], "<", &p[1]).await?,
-        "-0.0 not < +0.0 under block-ORE"
+    share_ore_order::<F4>(&pool).await?;
+    share_ore_order::<F8>(&pool).await
+}
+
+/// Generic body of `negative_zero_orders_below_positive_zero_under_ope`, run per
+/// float type: CLLW-OPE orders `-0.0 < +0.0` on `T`'s `_ord`.
+async fn orders_below_under_ope<T: SignedZeroPair>(pool: &PgPool) -> Result<()> {
+    let d = domain::<T>(Variant::Ord);
+    let p = signed_zero_payloads::<T>().await?;
+    anyhow::ensure!(
+        cmp_on(pool, &d, &p[0], "<", &p[1]).await?,
+        "-0.0 < +0.0 under CLLW-OPE ({d})"
     );
-    assert!(
-        !ord_ore_cmp(&pool, &p[1], "<", &p[0]).await?,
-        "+0.0 not < -0.0 under block-ORE"
+    anyhow::ensure!(
+        !cmp_on(pool, &d, &p[1], "<", &p[0]).await?,
+        "+0.0 not < -0.0 under CLLW-OPE ({d})"
     );
     Ok(())
 }
@@ -161,18 +223,11 @@ async fn negative_zero_orders_below_positive_zero_under_ope() -> Result<()> {
     // So the OPE-backed `_ord` domain DIVERGES from IEEE here, where block-ORE
     // agreed with it. This is a deliberate, pinned consequence of `_ord` moving
     // to CLLW-OPE — a float column that must treat ±0.0 as equal for ORDER BY
-    // should be typed `_ord_ore`.
+    // should be typed `_ord_ore`. `real` and `double` share the SEM, so both are
+    // pinned.
     let pool = setup().await?;
-    let p = encrypt_specials(&[F8(-0.0), F8(0.0)]).await?;
-    assert!(
-        ord_cmp(&pool, &p[0], "<", &p[1]).await?,
-        "-0.0 < +0.0 under CLLW-OPE"
-    );
-    assert!(
-        !ord_cmp(&pool, &p[1], "<", &p[0]).await?,
-        "+0.0 not < -0.0 under CLLW-OPE"
-    );
-    Ok(())
+    orders_below_under_ope::<F4>(&pool).await?;
+    orders_below_under_ope::<F8>(&pool).await
 }
 
 /// `-0.0` and `+0.0` are IEEE-equal, so encrypted `=` on `_eq` must agree.
@@ -193,24 +248,35 @@ async fn negative_zero_orders_below_positive_zero_under_ope() -> Result<()> {
 /// the test, so the ORE ordering canary below it had never actually executed.
 ///
 /// [#387]: https://github.com/cipherstash/encrypt-query-language/issues/387
-#[tokio::test]
-async fn negative_zero_and_positive_zero_compare_equal_under_eq() -> Result<()> {
-    let pool = setup().await?;
-    let p = encrypt_specials(&[F8(-0.0), F8(0.0)]).await?;
+///
+/// Generic body of `negative_zero_and_positive_zero_compare_equal_under_eq`, run
+/// per float type against `T`'s `_eq` domain (e.g. `public.eql_v3_real_eq` /
+/// `public.eql_v3_double_eq`). Keeps the `known_failure` inversion intact per
+/// type.
+async fn eq_split<T: SignedZeroPair>(pool: &PgPool) -> Result<()> {
+    let d = domain::<T>(Variant::Eq);
+    let p = signed_zero_payloads::<T>().await?;
 
-    let equal = eq_cmp(&pool, &p[0], &p[1]).await?;
+    let equal = cmp_on(pool, &d, &p[0], "=", &p[1]).await?;
     let assertion = if equal {
         Ok(())
     } else {
         Err(anyhow::anyhow!(
-            "encrypted `=` on public.eql_v3_double_eq returned false for -0.0 vs +0.0"
+            "encrypted `=` on {d} returned false for -0.0 vs +0.0"
         ))
     };
     known_failure(
         ISSUE_FLOAT_SIGNED_ZERO_EQ,
-        "-0.0 == +0.0 under public.eql_v3_double_eq",
+        &format!("-0.0 == +0.0 under {d}"),
         assertion,
     )
+}
+
+#[tokio::test]
+async fn negative_zero_and_positive_zero_compare_equal_under_eq() -> Result<()> {
+    let pool = setup().await?;
+    eq_split::<F4>(&pool).await?;
+    eq_split::<F8>(&pool).await
 }
 
 /// `=` on the OPE-backed `_ord` domain splits `±0.0` too — pinned, and pinned
@@ -231,44 +297,64 @@ async fn negative_zero_and_positive_zero_compare_equal_under_eq() -> Result<()> 
 ///
 /// Contrast [`negative_zero_and_positive_zero_compare_equal_under_ord_ore`]:
 /// block-ORE canonicalizes, so `=` there already agrees with IEEE and needs no
-/// marker. `real` shares this SEM with `double`; one type is pinned, as
-/// everywhere else in this module.
+/// marker. `real` shares this SEM with `double`; both are pinned, as everywhere
+/// else in this module.
 ///
 /// [#387]: https://github.com/cipherstash/encrypt-query-language/issues/387
-#[tokio::test]
-async fn negative_zero_and_positive_zero_compare_equal_under_ord() -> Result<()> {
-    let pool = setup().await?;
-    let p = encrypt_specials(&[F8(-0.0), F8(0.0)]).await?;
+///
+/// Generic body of `negative_zero_and_positive_zero_compare_equal_under_ord`,
+/// run per float type against `T`'s OPE-backed `_ord` domain. Keeps the
+/// `known_failure` inversion intact per type.
+async fn ord_split<T: SignedZeroPair>(pool: &PgPool) -> Result<()> {
+    let d = domain::<T>(Variant::Ord);
+    let p = signed_zero_payloads::<T>().await?;
 
-    let equal = ord_cmp(&pool, &p[0], "=", &p[1]).await?;
+    let equal = cmp_on(pool, &d, &p[0], "=", &p[1]).await?;
     let assertion = if equal {
         Ok(())
     } else {
         Err(anyhow::anyhow!(
-            "encrypted `=` on public.eql_v3_double_ord returned false for -0.0 vs +0.0"
+            "encrypted `=` on {d} returned false for -0.0 vs +0.0"
         ))
     };
     known_failure(
         ISSUE_FLOAT_SIGNED_ZERO_EQ,
-        "-0.0 == +0.0 under public.eql_v3_double_ord",
+        &format!("-0.0 == +0.0 under {d}"),
         assertion,
     )
+}
+
+#[tokio::test]
+async fn negative_zero_and_positive_zero_compare_equal_under_ord() -> Result<()> {
+    let pool = setup().await?;
+    ord_split::<F4>(&pool).await?;
+    ord_split::<F8>(&pool).await
+}
+
+/// Generic body of `negative_zero_and_positive_zero_compare_equal_under_ord_ore`,
+/// run per float type: `=` on `T`'s block-ORE `_ord_ore` agrees with IEEE.
+async fn ord_ore_equal<T: SignedZeroPair>(pool: &PgPool) -> Result<()> {
+    let d = domain::<T>(Variant::OrdOre);
+    let p = signed_zero_payloads::<T>().await?;
+    anyhow::ensure!(
+        cmp_on(pool, &d, &p[0], "=", &p[1]).await?,
+        "-0.0 = +0.0 under block-ORE `_ord_ore` \
+         (orderable-bytes canonicalizes the sign of zero) ({d})"
+    );
+    Ok(())
 }
 
 /// `=` on the block-ORE `_ord_ore` domain agrees with IEEE: the
 /// `orderable-bytes` encoder canonicalizes `-0.0 -> +0.0` before encoding, so
 /// both zeroes share one `ob` term. Asserted unconditionally — this is the
 /// behaviour `_ord` had before the CLLW-OPE flip, and the reason a float column
-/// needing IEEE `±0.0` semantics should be typed `_ord_ore`.
+/// needing IEEE `±0.0` semantics should be typed `_ord_ore`. `real` and `double`
+/// share the encoder, so both are pinned.
 #[tokio::test]
 async fn negative_zero_and_positive_zero_compare_equal_under_ord_ore() -> Result<()> {
     let pool = setup().await?;
-    let p = encrypt_specials(&[F8(-0.0), F8(0.0)]).await?;
-    assert!(
-        ord_ore_cmp(&pool, &p[0], "=", &p[1]).await?,
-        "-0.0 = +0.0 under block-ORE `_ord_ore` (orderable-bytes canonicalizes the sign of zero)"
-    );
-    Ok(())
+    ord_ore_equal::<F4>(&pool).await?;
+    ord_ore_equal::<F8>(&pool).await
 }
 
 #[tokio::test]

--- a/tests/sqlx/tests/encrypted_domain/property/edge_cases.rs
+++ b/tests/sqlx/tests/encrypted_domain/property/edge_cases.rs
@@ -151,14 +151,24 @@ async fn check_rejects_payload_missing_hm(pool: PgPool) -> Result<()> {
 }
 
 #[sqlx::test]
-async fn check_rejects_payload_missing_ob(pool: PgPool) -> Result<()> {
-    // The _ord and _ord_ore domain CHECKs both require `ob`. A payload without
-    // it must be rejected at the cast on either ordered twin.
-    let no_ob = r#"{"v":3,"i":{"t":"edge","c":"payload"},"c":"AAAA","hm":"deadbeef"}"#;
-    for variant in [Variant::Ord, Variant::OrdOre] {
-        let d = integer(variant);
-        let sql = format!("SELECT $1::jsonb::{d}");
-        assert_raises(&pool, &sql, &[Some(no_ob)], "violates check constraint").await?;
-    }
-    Ok(())
+async fn check_ord_rejects_payload_missing_op(pool: PgPool) -> Result<()> {
+    // Post CLLW-OPE flip, the `_ord` domain is OPE-backed and its CHECK requires
+    // `op` (not `ob`). A payload carrying `ob` (and `hm`) but no `op` must be
+    // rejected at the cast — proving `_ord` genuinely needs the OPE term, not the
+    // ORE `ob` array it no longer references.
+    let d = integer(Variant::Ord);
+    let no_op = r#"{"v":3,"i":{"t":"edge","c":"payload"},"c":"AAAA","hm":"deadbeef","ob":["00"]}"#;
+    let sql = format!("SELECT $1::jsonb::{d}");
+    assert_raises(&pool, &sql, &[Some(no_op)], "violates check constraint").await
+}
+
+#[sqlx::test]
+async fn check_ord_ore_rejects_payload_missing_ob(pool: PgPool) -> Result<()> {
+    // The `_ord_ore` domain is ORE-backed and its CHECK requires the `ob` array.
+    // A payload carrying `op` (and `hm`) but no `ob` must be rejected at the cast
+    // — proving `_ord_ore` genuinely needs the ORE term, not the OPE `op` scalar.
+    let d = integer(Variant::OrdOre);
+    let no_ob = r#"{"v":3,"i":{"t":"edge","c":"payload"},"c":"AAAA","hm":"deadbeef","op":"00"}"#;
+    let sql = format!("SELECT $1::jsonb::{d}");
+    assert_raises(&pool, &sql, &[Some(no_ob)], "violates check constraint").await
 }

--- a/tests/sqlx/tests/encrypted_domain/property/fixture_oracle.rs
+++ b/tests/sqlx/tests/encrypted_domain/property/fixture_oracle.rs
@@ -492,4 +492,18 @@ mod text_fn {
         })
         .await
     }
+
+    /// `text_search_ore` ([Hm, Ore, Bloom]) — the ORE twin of `text_search`. Same
+    /// eq/ord function facets plus eq_term + ord_term_ore identity, but ordering
+    /// rides the block-ORE term (`ord_term_ore`/`ob`) instead of the OPE term
+    /// (`ord_term`/`op`). The bloom `@>`/`<@` facet is covered by `match_smoke`.
+    #[sqlx::test]
+    async fn search_ore_fn_oracle(pool: PgPool) -> Result<()> {
+        run_fn_property::<String, _, _>(pool, 32, |pool, c| async move {
+            assert_eq_fn_oracle::<String>(&pool, Variant::SearchOre, &c).await?;
+            assert_ord_fn_oracle::<String>(&pool, Variant::SearchOre, &c).await?;
+            assert_extractor_oracle::<String>(&pool, Variant::SearchOre, &c).await
+        })
+        .await
+    }
 }

--- a/tests/sqlx/tests/v3_ore_fallback_tests.rs
+++ b/tests/sqlx/tests/v3_ore_fallback_tests.rs
@@ -304,17 +304,21 @@ async fn superuser_install_creates_opclass_and_poisons_nothing(pool: PgPool) -> 
         "a superuser install must not poison any domain"
     );
 
-    let ord = eql_domains::scalar_families()
+    // Re-point at the ORE domain: `_ord` is OPE (UNPOISONABLE by construction),
+    // so casting into it proves nothing about the superuser path. `_ord_ore` is
+    // the poisonable ORE domain — on a superuser install it must NOT be poisoned
+    // and must accept values, making this a meaningful positive control.
+    let ord_ore = eql_domains::scalar_families()
         .find(|s| s.name == "integer")
-        .and_then(|s| s.domains.iter().find(|d| d.name == "ord"))
-        .expect("integer_ord in catalog");
+        .and_then(|s| s.domains.iter().find(|d| d.name == "ord_ore"))
+        .expect("integer_ord_ore in catalog");
     try_cast(
         &pool,
-        "public.eql_v3_integer_ord",
-        &column_payload(ord.terms),
+        "public.eql_v3_integer_ord_ore",
+        &column_payload(ord_ore.terms),
     )
     .await
-    .expect("integer_ord accepts values on a superuser install");
+    .expect("integer_ord_ore accepts values on a superuser install");
     Ok(())
 }
 

--- a/tests/sqlx/tests/v3_privilege_tests.rs
+++ b/tests/sqlx/tests/v3_privilege_tests.rs
@@ -44,6 +44,16 @@ const ORD_QUERY: &str =
     "SELECT count(*) FROM fixtures.eql_v3_integer a, fixtures.eql_v3_integer b \
      WHERE a.payload::public.eql_v3_integer_ord < b.payload::public.eql_v3_integer_ord";
 
+/// The block-ORE counterpart of [`ORD_QUERY`]: the `<` *operator* on
+/// `integer_ord_ore`, dispatching through `eql_v3.lt` → `eql_v3.ord_term_ore` →
+/// the `eql_v3_internal.ore_block_256` comparator, whose comparison calls
+/// pgcrypto `encrypt()` (resolved through the `extensions` schema via the
+/// comparator's `SET search_path = pg_catalog, extensions, public`). Unlike the
+/// CLLW-OPE `ORD_QUERY`, this path needs USAGE on `extensions`.
+const ORD_ORE_QUERY: &str =
+    "SELECT count(*) FROM fixtures.eql_v3_integer a, fixtures.eql_v3_integer b \
+     WHERE a.payload::public.eql_v3_integer_ord_ore < b.payload::public.eql_v3_integer_ord_ore";
+
 /// A real aggregate (`eql_v3.min` on `integer_ord`). The public aggregate dispatches
 /// into its state function `eql_v3_internal.min_sfunc`, so it requires the
 /// internal grant.
@@ -155,6 +165,27 @@ fn assert_insufficient_privilege(err: sqlx::Error, context: &str) {
     );
 }
 
+/// Assert a query failed at the pgcrypto / `extensions` boundary: a database
+/// error whose message names pgcrypto's `encrypt` or the `extensions` schema.
+///
+/// The ORE comparator calls `encrypt()` unqualified, resolved through its
+/// `SET search_path = pg_catalog, extensions, public`. When the caller lacks
+/// USAGE on `extensions`, PostgreSQL skips that schema during name resolution,
+/// so this surfaces as `undefined_function` ("function encrypt(...) does not
+/// exist") rather than a plain `permission denied for schema extensions`
+/// (`insufficient_privilege`). Both name the boundary, so the assertion pins the
+/// message reference, not the exact SQLSTATE.
+fn assert_pgcrypto_boundary_error(err: sqlx::Error, context: &str) {
+    let db_err = err
+        .as_database_error()
+        .unwrap_or_else(|| panic!("{context}: expected a database error, got: {err:?}"));
+    let msg = db_err.message().to_ascii_lowercase();
+    assert!(
+        msg.contains("encrypt") || msg.contains("extensions"),
+        "{context}: expected an error naming the pgcrypto `encrypt` / `extensions` boundary, got: {db_err:?}"
+    );
+}
+
 // ============================================================================
 // Scalar operator surface
 // ============================================================================
@@ -233,6 +264,55 @@ async fn runtime_role_without_internal_grant_is_denied(pool: PgPool) -> Result<(
             ));
         assert_insufficient_privilege(err, label);
     }
+
+    sqlx::query("RESET ROLE").execute(&mut *conn).await?;
+    drop_role(&mut conn, &role).await?;
+    Ok(())
+}
+
+/// Boundary (OPE vs ORE): a runtime role granted USAGE + EXECUTE on BOTH EQL
+/// schemas and read on the fixture — but deliberately NOT USAGE on `extensions`
+/// (pgcrypto) — can run the default CLLW-OPE ordering path (`_ord`) yet is denied
+/// the block-ORE ordering path (`_ord_ore`). Pins the pgcrypto boundary that
+/// motivates preferring `_ord`: the OPE comparator (`eql_v3_internal.ope_cllw`)
+/// compares hex-decoded `bytea` natively and never touches pgcrypto, so it needs
+/// no `extensions` grant; the ORE comparator (`eql_v3_internal.ore_block_256`)
+/// calls pgcrypto `encrypt()` (resolved through `extensions`), so under the
+/// identical grant set the same `<` query fails at the crypto call.
+///
+/// The positive `runtime_role_with_both_schema_grants_can_query` already runs
+/// `_ord` without an `extensions` grant; this adds the contrasting ORE denial
+/// under the SAME grants, so the two ordering paths are proven to diverge on
+/// exactly the `extensions` grant — not on anything else.
+#[sqlx::test(fixtures(path = "../fixtures", scripts("eql_v3_integer")))]
+async fn runtime_role_ope_ok_ore_needs_extensions(pool: PgPool) -> Result<()> {
+    let mut conn = pool.acquire().await?;
+    let role = create_isolated_role(&mut conn).await?;
+
+    grant_fixture_access(&mut conn, &role, &["eql_v3_integer"]).await?;
+    grant_schema(&mut conn, &role, "eql_v3").await?;
+    grant_schema(&mut conn, &role, "eql_v3_internal").await?;
+    // Deliberately NO grant on `extensions` (pgcrypto) — the whole point: it is
+    // what separates the OPE path (below, allowed) from the ORE path (denied).
+
+    sqlx::query(&format!("SET ROLE \"{role}\""))
+        .execute(&mut *conn)
+        .await?;
+
+    // (a) The CLLW-OPE `_ord` ordering path succeeds without the extensions grant.
+    let ope_pairs: i64 = sqlx::query_scalar(ORD_QUERY).fetch_one(&mut *conn).await?;
+    assert!(
+        ope_pairs > 0,
+        "the CLLW-OPE `_ord` ordering path must succeed without an `extensions` grant"
+    );
+
+    // (b) The block-ORE `_ord_ore` ordering path is denied: its comparator calls
+    // pgcrypto `encrypt()` in `extensions`, which this role cannot reach.
+    let err = sqlx::query(ORD_ORE_QUERY)
+        .fetch_one(&mut *conn)
+        .await
+        .expect_err("the block-ORE `_ord_ore` path must fail without an `extensions` grant");
+    assert_pgcrypto_boundary_error(err, "ore ordering without extensions grant");
 
     sqlx::query("RESET ROLE").execute(&mut *conn).await?;
     drop_role(&mut conn, &role).await?;


### PR DESCRIPTION
Addresses [CIP-3491](https://linear.app/cipherstash/issue/CIP-3491) — **5 of 6 items**; item R2b is infeasible as specified (see below).

> **Stacked on #399** (CIP-3490). Base is the `cip-3490` branch to avoid conflicts on `v3_privilege_tests.rs` / `fixture_oracle.rs`, which #399 also touches. Retarget to `main` once #399 merges.

Tests that passed for the wrong reason, or didn't exist, after the block-ORE → CLLW-OPE flip. Ground truth: `_ord`/`_ord_ope` are OPE (`op`, `ord_term`, native bytea, **unpoisonable**, no pgcrypto); `_ord_ore`/`_search_ore` are block-ORE (`ob`, `ord_term_ore`, **poisonable**, pgcrypto `encrypt()`).

### Done (5)
- **R2a — vacuous positive control** (`v3_ore_fallback_tests.rs`). The superuser "poisons nothing" control cast `public.eql_v3_integer_ord` — the OPE domain, which is unpoisonable *by construction*, so it could never fail. Re-pointed at `public.eql_v3_integer_ord_ore` (the poisonable ORE domain), making it a meaningful control.
- **PR#392 — stale `check_rejects_payload_missing_ob`** (`edge_cases.rs`). Post-flip `_ord` requires `op`, not `ob`, so the old test passed for the wrong reason. Split into `check_ord_rejects_payload_missing_op` (`_ord`/OPE) and `check_ord_ore_rejects_payload_missing_ob` (`_ord_ore`/ORE), each proving its domain needs its own ordering term.
- **T18 — `real`/F4 signed-zero untested** (`float_special.rs`). The ±0.0 pins ran for `double`/F8 only, though `real` shares the crypto path. Parameterised all five ±0.0 tests over F4 **and** F8 via a local `SignedZeroPair` trait + generic helper bodies; `known_failure(ISSUE_FLOAT_SIGNED_ZERO_EQ, …)` inversion preserved per type (F4 arm now pins `public.eql_v3_real_eq`/`_ord`).
- **R3a — missing SearchOre oracle** (`fixture_oracle.rs`). Added `search_ore_fn_oracle` for `Variant::SearchOre` (`text_search_ore`, `[Hm,Ore,Bloom]`) — the block-ORE twin of the existing OPE `search_fn_oracle`, so `SearchOre` gets all-pairs oracle coverage.
- **T10 — OPE privilege-path control** (`v3_privilege_tests.rs`). #399 already dropped the dead `extensions` grant from the positive test (so `_ord`/OPE is now exercised without it). This adds `runtime_role_ope_ok_ore_needs_extensions`: under identical grants minus `extensions`, the OPE `_ord` `<` succeeds while the ORE `_ord_ore` `<` fails at pgcrypto `encrypt()` — pinning that the two paths diverge on *exactly* the `extensions` grant. The error assertion (`assert_pgcrypto_boundary_error`) matches on the message naming `encrypt`/`extensions` rather than a fixed SQLSTATE, since a missing `extensions` USAGE surfaces as `undefined_function` (name resolution skips the schema), not necessarily `insufficient_privilege`.

### Not done — R2b is infeasible as specified
The ticket asks to add `"1.0"` to `NUMERIC_FIXTURES` to exercise the `numeric._ord` scale collision. **This breaks CI.** `rust_decimal` parses `"1"` and `"1.0"` to the *same* value, tripping the deliberate `numeric_value_guards::fixtures_are_distinct_by_value` guard — whose own doc (`tests/sqlx/src/scalar_domains.rs:697`) names this exact pair as forbidden, because the fixture table keys `plaintext` by numeric value and two aliasing rows break `fetch_fixture_payload`'s `fetch_one`. Empirically: `cargo test -p eql-domains` passes (a false green — the catalog keys numeric fixtures by literal string), but `cargo test --lib -p eql_tests` fails with "two numeric fixtures alias to the same Decimal value". The scale-collision intent needs a **standalone fresh-encryption test** (like `float_special`'s NaN pins), not a one-line fixture-list addition — a larger change than R2b's stated scope, left for a decision. **CIP-3491 should stay open for R2b** (re-scoped).

### Verification (no creds locally)
`cargo fmt --check` clean; `cargo test -p eql-domains` 93 pass; `cargo check --lib -p eql_tests` clean; `cargo check --tests -p eql_tests` shows **0 real rustc errors** — the only failures are the expected `couldn't read fixtures/*.sql` macro errors (integration targets need creds-generated fixtures; CI has them). Test-only change, no changeset.