### PR TITLE
Fix release image workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,12 @@ jobs:
           VERSION: ${{ needs.release.outputs.version }}
         run: |
           set -euo pipefail
-          gh workflow run release-postgres-eql-image.yml --ref "eql-${VERSION}" \
+          # This job deliberately has no checkout. Pass --repo explicitly so
+          # gh does not try to infer the repository from a nonexistent .git
+          # directory.
+          gh workflow run release-postgres-eql-image.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref "eql-${VERSION}" \
             -f eql_version="$VERSION" \
             -f update_floating_tags=true
 


### PR DESCRIPTION
## Summary

Fix the production release workflow's Postgres+EQL image dispatch when the job runs without a repository checkout.

`gh workflow run` otherwise tries to infer the repository from the current directory and fails with:

```text
fatal: not a git repository (or any of the parent directories): .git
```

Passing `--repo "$GITHUB_REPOSITORY"` makes the dispatch independent of local Git metadata, matching the existing prerelease Rust dispatch pattern.

## Verification

- `release.yml` parses as YAML.
- The equivalent explicit-repository command successfully dispatched the 3.0.2 Postgres+EQL recovery build.
- Commit is GPG verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the automated release process for PostgreSQL EQL images.
  * Release workflow dispatching is now more explicit and reliable, helping ensure images are built and published from the intended repository and version reference.
  * No changes were made to public features or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->