### PR TITLE
chore(release): bump grouped_value changeset to patch (3.0.3, not 3.1.0)

### DIFF
--- a/.changeset/grouped-value-v3.md
+++ b/.changeset/grouped-value-v3.md
@@ -1,5 +1,5 @@
 ---
-'@cipherstash/eql': minor
+'@cipherstash/eql': patch
 ---
 
 **`eql_v3.grouped_value(jsonb)` lets you project an encrypted column while grouping by its equality term.** Grouping encrypted rows by equality requires `GROUP BY eql_v3.eq_term(col)` (the deterministic HMAC term — the ciphertext envelope itself is not equality-comparable), but PostgreSQL then rejects a bare `SELECT col` with "column must appear in the GROUP BY clause or be used in an aggregate function", because it cannot prove the column is constant within each term group. Wrapping the column in `eql_v3.grouped_value(col)` returns one representative encrypted value per group and satisfies the rule — e.g. `SELECT eql_v3.grouped_value(encrypted_foo), count(*) FROM t GROUP BY eql_v3.eq_term(encrypted_foo)`. It accepts any eql_v3 encrypted-domain value (all are jsonb-backed domains), returns it unchanged (no decryption or comparison), and is `PARALLEL SAFE` with a combine function, matching the `min`/`max` aggregate shape. Why: this re-creates the `grouped_value` aggregate that the eql_v2 surface provided and that was dropped in 3.0.0 with no eql_v3 equivalent until now.


### PR DESCRIPTION
The [Version Packages PR (#424)](https://github.com/cipherstash/encrypt-query-language/pull/424) computed **3.1.0**. That came entirely from `.changeset/grouped-value-v3.md` declaring `minor` — Changesets takes the max bump across pending changesets, and the only other pending one (`empty-bloom-match-guard.md`) is `patch`.

This flips that one line to `patch`, so the bot regenerates #424 as **3.0.3**.

Rationale for patch over minor: `eql_v3.grouped_value` re-creates the aggregate the `eql_v2` surface provided and that 3.0.0 dropped with no `eql_v3` equivalent — restoring parity rather than opening a 3.1 line.

Changeset body text is untouched, so the `CHANGELOG.md` entry is unchanged apart from the version heading.

## After merge

The Changesets bot re-runs on `main` and rewrites #424 (`3.1.0` → `3.0.3`) across `packages/eql/package.json`, `crates/eql-bindings/Cargo.toml`, `Cargo.lock`, both bundled SQL release manifests, and `packages/eql/CHANGELOG.md`. No manual edit to that branch is needed — and any manual edit would have been clobbered by this same re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release classification for `@cipherstash/eql` from a minor release to a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->