### PR TITLE
docs(reference): document eq_term/ord_term for SELECT DISTINCT + ORDER BY

### DIFF
--- a/docs/reference/database-indexes.md
+++ b/docs/reference/database-indexes.md
@@ -189,6 +189,38 @@ Why the raw column does not scale: `GROUP BY col` uses the entire encrypted payl
 
 Pick the extractor the domain actually has: `eq_term` exists only on the `hm`-carrying domains. On a numeric-and-time `_ord` / `_ord_ope` / `_ord_ore` column, group on the ordering extractor instead — `GROUP BY eql_v3.ord_term(col)` (or `ord_term_ore(col)`). The ordering term is injective for those types, so it is an exact grouping key, and the column's ordering btree covers it.
 
+#### `SELECT DISTINCT` is keyed on `eq_term`
+
+`SELECT DISTINCT` on an encrypted column has the same scaling problem as `GROUP BY` on the raw column, plus a correctness one: the raw jsonb payload includes the randomised ciphertext `c`, so two rows holding identical plaintext never compare equal on the raw column and `DISTINCT` never collapses them. [CipherStash Proxy](https://github.com/cipherstash/proxy) rewrites `DISTINCT` on an encrypted column to key on its equality term instead:
+
+```sql
+-- as written
+SELECT DISTINCT enc FROM t;
+
+-- as rewritten by Proxy
+SELECT DISTINCT ON (eql_v3.eq_term(enc)) enc FROM t;
+```
+
+Because dedup is equality-based, this requires the column's domain to carry an equality term. A storage-only domain with no `eq_term` overload — `public.eql_v3_boolean`, which ships no `_eq` / `_ord` variant (see [SQL support](./sql-support.md)) — cannot be deduplicated this way; `DISTINCT` on it is a capability error rather than a silent fallback to comparing raw ciphertext.
+
+#### `SELECT DISTINCT … ORDER BY` additionally requires `ord_term`
+
+Ordering an encrypted column under `DISTINCT` needs `eql_v3.ord_term(col)` too. PostgreSQL requires every `ORDER BY` expression under `DISTINCT ON` to appear in the select list, so Proxy pushes the query into a subquery that projects the ordering term, then applies `ORDER BY` in a non-`DISTINCT` outer query around it:
+
+```sql
+-- as written
+SELECT DISTINCT enc FROM t ORDER BY enc;
+
+-- as rewritten by Proxy (conceptually — column names/aliases are preserved)
+SELECT enc FROM (
+  SELECT DISTINCT ON (eql_v3.eq_term(enc)) enc, eql_v3.ord_term(enc) AS order_term
+    FROM t
+) sub
+ORDER BY order_term;
+```
+
+The ordering term (`order_term` above) is never returned to the client. This rewrite happens entirely in Proxy — EQL SQL only supplies the `eq_term` / `ord_term` extractors it relies on.
+
 ### Field-level ordering index (ste_vec elements)
 
 Entry-to-entry `=` / `<>` and exact `GROUP BY` / `DISTINCT` on extracted

--- a/docs/reference/eql-functions.md
+++ b/docs/reference/eql-functions.md
@@ -114,6 +114,8 @@ CREATE INDEX ON users USING gin   (eql_v3.match_term(name_match));
 
 > The full per-domain operator / wrapper / blocker surface (and the `public.<T>` / `_eq` / `_ord` / `_ord_ope` / `_ord_ore` domain types themselves) is documented in [SQL support](./sql-support.md#encrypted-domain-scalar-types-publict) and the [scalar encrypted-domain type reference](./adding-a-scalar-encrypted-domain-type.md).
 
+> **`eq_term` / `ord_term` also back `SELECT DISTINCT`.** [CipherStash Proxy](https://github.com/cipherstash/proxy) keys `DISTINCT` on an encrypted column by `eq_term` (dedup by plaintext equality, not raw ciphertext) and, when combined with `ORDER BY` on an encrypted column, additionally requires `ord_term`. A domain with no `eq_term` (e.g. the storage-only `public.eql_v3_boolean`) cannot be deduplicated. See [`GROUP BY` / `DISTINCT`](./database-indexes.md#group-by--distinct) for the rewrite Proxy performs.
+
 The `public.eql_v3_json_search` document type extracts its entry ordering term
 with `eql_v3.ord_term(public.eql_v3_json_entry)`. The low-level
 `eql_v3.ope_term(public.eql_v3_json_entry)` exposes the same lossy `op` bytes for


### PR DESCRIPTION
## CIP-3677 — Document `SELECT DISTINCT` + `ORDER BY` on encrypted columns (EQL docs)

Makes the `DISTINCT` / `ORDER BY` behaviour that landed in the Proxy EQL mapper discoverable from the EQL reference docs, via the `eq_term` / `ord_term` extractors.

### Changes (docs only)
- `docs/reference/database-indexes.md` — extends the existing **GROUP BY / DISTINCT** section:
  - `SELECT DISTINCT` on an encrypted column is keyed on `eql_v3.eq_term(col)` (dedup by plaintext; raw-column `DISTINCT` never collapses identical plaintexts because ciphertext `c` is randomised). Includes the rewrite and the capability-error consequence for storage-only domains (`eql_v3_boolean`).
  - `SELECT DISTINCT … ORDER BY <encrypted col>` additionally requires `eql_v3.ord_term(col)`, with the subquery-projecting-the-term rewrite; the ordering term is never returned to the client and aliases are preserved.
- `docs/reference/eql-functions.md` — cross-reference from the Index Term Extraction section.

### Scope note
This covers the **encrypt-query-language repo** portion of CIP-3677 only. The public **website-docs** portion of the ticket lives in a separate repository and is tracked/handled there.

No SQL/Rust/test changes; no changeset (docs-only, describing Proxy behaviour rather than an EQL code/behaviour change).

Part of CIP-3677