### PR TITLE
Retarget ste_vec_contains rename changeset to patch

### DIFF
--- a/.changeset/rename-ste-vec-contains.md
+++ b/.changeset/rename-ste-vec-contains.md
@@ -1,10 +1,23 @@
 ---
-'@cipherstash/eql': major
+'@cipherstash/eql': patch
 ---
 
 **`eql_v3.ste_vec_contains` is renamed to `eql_v3.jsonb_document_contains`.** This
 consolidates the last `ste_vec_*`-named public object into the `jsonb_*` family,
 matching the earlier renames of the SteVec entry/query surface (`jsonb_entry`,
-`jsonb_query`). The function backs the `json` `@>` / `<@` containment operators;
-its behaviour is unchanged. Callers that invoke the function by name (Supabase /
-PostgREST, which call functions rather than operators) must update the name.
+`jsonb_query`). The `@>` / `<@` containment operators are untouched, and so are
+the raw-jsonb function-form entry points, `eql_v3.jsonb_contains(jsonb, jsonb)`
+and `eql_v3.jsonb_contained_by(jsonb, jsonb)` — a PostgREST deployment calling
+those by name sees no change.
+
+What breaks is hand-written SQL that names `ste_vec_contains` directly: queries,
+views, and RLS policies that call it, and any per-function `GRANT EXECUTE ON
+FUNCTION eql_v3.ste_vec_contains(...)`. The schema-wide grant recipes in
+`docs/reference/permissions.md` (`GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA
+eql_v3 ...`) pick the new name up automatically on their next run; a stale
+per-function grant referencing the old name fails loudly at apply time
+(`function eql_v3.ste_vec_contains(...) does not exist`) rather than silently
+granting nothing. And underneath all of it: the installer opens with `DROP
+SCHEMA IF EXISTS eql_v3 CASCADE`, so every EQL install already drops and
+recreates grants, functional indexes, and dependent views on upgrade — that is
+not new behaviour introduced by this rename.


### PR DESCRIPTION
## Summary
- `.changeset/rename-ste-vec-contains.md` was declaring `major`. It should be `patch`: 3.0.1 shipped an operator behaviour change (`@>`/`<@` → `@@`) as a patch, and this rename leaves the operators (and the `jsonb_contains`/`jsonb_contained_by` function-form entry points) untouched — same level. As `major` this would have released 4.0.0; the downstream absorbed tree (`cipherstash/stack`) expects `3.0.5`.
- Rewrote the changeset body: verified against `src/v3/json/functions.sql` that `eql_v3.jsonb_contains(jsonb, jsonb)` and `eql_v3.jsonb_contained_by(jsonb, jsonb)` are untouched by the rename (a PostgREST deployment calling those by name sees no change). The previous prose overstated the blast radius. The rewritten body scopes what actually breaks (hand-written SQL naming `ste_vec_contains` directly — queries, views, RLS, per-function grants) and notes the schema-wide grant recipes in `docs/reference/permissions.md` pick the new name up automatically, while a stale per-function grant fails loudly rather than silently. Also notes the installer already opens with `DROP SCHEMA IF EXISTS eql_v3 CASCADE` on every install/upgrade — not new behaviour from this rename.

This is the last release from this repository — the EQL subsystem has been absorbed into `cipherstash/stack`, and 3.0.5 is what puts a version on npm matching what the absorbed tree already carries.

## Test plan
- [x] Confirmed `eql_v3.jsonb_contains`/`jsonb_contained_by` (raw jsonb, 2-arg) are separate overloads from the renamed `jsonb_document_contains`, unaffected by the rename
- [x] Confirmed `release/cipherstash-encrypt.sql` opens with `DROP SCHEMA IF EXISTS eql_v3 CASCADE`
- [ ] Merge triggers Changesets Version PR bumping `@cipherstash/eql` 3.0.4 → 3.0.5 (patch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Renamed `eql_v3.ste_vec_contains` to `eql_v3.jsonb_document_contains`.
  - Existing containment operators and raw JSONB function entry points remain unchanged.
  - Direct SQL callers using the former function name should update their queries.
  - Function-specific access grants now apply to the renamed function.
  - This update is delivered as a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->