### PR TITLE
docs(readme): lead the existing-database install with the stash CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,20 @@ EQL is installed automatically on first boot. Pin a specific version with `:17-<
 
 ### Install into an existing database
 
-Execute the install SQL file directly:
+Use the `stash` CLI (recommended):
+
+```sh
+npx stash eql install
+```
+
+It connects using `DATABASE_URL` (or `--database-url` for a one-shot run), checks your role's
+capabilities first (`npx stash eql preflight` runs the same checks standalone), installs as a
+non-superuser, and prints any optional superuser-gated statements it skipped instead of failing
+on them. On platforms where schema changes must go through a migration tool, generate a
+migration instead: `npx stash eql migration --supabase` (or `--drizzle`).
+
+<details>
+<summary>Alternative: apply the raw SQL yourself</summary>
 
 1. Download the latest EQL install script:
 
@@ -65,6 +78,15 @@ Execute the install SQL file directly:
    ```sh
    psql -f cipherstash-encrypt.sql
    ```
+
+> [!WARNING]
+> The bundle is ~6,000 statements and `psql -f` sends one statement per protocol round trip. Over a
+> pooled or high-latency connection — or under a platform command-time ceiling (some managed
+> platforms kill commands after a fixed limit) — this can time out **partway**, leaving a
+> half-installed schema. If you cannot use the CLI, apply the file over a direct (non-pooled)
+> connection, or split it at statement boundaries and apply each chunk as a single command.
+
+</details>
 
 
 ## EQL Components


### PR DESCRIPTION
## Summary

The README's only instruction for installing EQL (the SQL library that becomes the `eql_v3` schema) into an existing database was: download the release SQL, run `psql -f`. That path has a real failure mode we hit live — the bundle is ~6,000 statements and `psql -f` sends one per protocol round trip, so over a pooled connection or under a platform command-time ceiling (managed AI platforms kill commands at a fixed limit) the install dies partway and leaves a half-installed schema. This makes `npx stash eql install` the primary instruction and demotes the raw-SQL path to a collapsible alternative with a warning.

## Changes

- "Install into an existing database" now leads with `npx stash eql install`: connects via `DATABASE_URL` or `--database-url` (one-shot), preflights role capability (`stash eql preflight`), installs as a non-superuser, prints skipped optional superuser-gated statements instead of failing. Points at `stash eql migration --supabase|--drizzle` for migration-tool platforms.
- Raw-SQL instructions kept verbatim inside a `<details>` block, plus a warning: the per-statement round-trip hazard, and the mitigations (direct non-pooled connection, or statement-boundary chunking applied one chunk per command).

## Verification

Docs-only. The hazard is from a live run: applying the 3.0.4 bundle with `psql -f` over a pooled connection timed out at a managed platform's 600-second ceiling mid-bundle and half-installed the schema; recovery was 27 statement-boundary chunks applied one `psql -c` each (full record in cipherstash/skilltester branch `20260819-01-lovable`, `apps/lovable-cloud/.cipherstash/bug-eql-bundle-psql-timeout.md`). CLI flag claims verified against the published `stash@1.1.0` (shared `--database-url` flag on every db/eql command; one-shot semantics). Commit signed.

## Related

Refs cipherstash/stack#665. Companion skill update: cipherstash/stack#929.

https://claude.ai/code/session_013d6Ni8tR7FfxPos9TdEuDs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to recommend the `stash` CLI.
  * Added details on database URL handling, capability checks, non-superuser installations, and migration generation.
  * Documented skipped superuser-only statements and retained raw SQL installation as an alternative.
  * Added a warning about potential `psql` timeouts and partial installations on pooled or high-latency connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->