### PR TITLE
fix(deps): patch hickory-proto to 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1118,18 +1128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.108",
-]
-
-[[package]]
 name = "eql-bindings"
 version = "3.0.5"
 dependencies = [
@@ -1206,7 +1204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1604,23 +1602,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebdb29d2ea9ed0083cd8cece49bbd968021bd99b0849edb4a9a7ee0fdf6a4e0"
 
 [[package]]
-name = "hickory-proto"
-version = "0.25.2"
+name = "hickory-net"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
  "data-encoding",
- "enum-as-inner",
  "futures-channel",
  "futures-io",
  "futures-util",
+ "hickory-proto",
  "idna",
  "ipnet",
- "once_cell",
- "rand 0.9.4",
- "ring",
+ "jni",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -1629,21 +1626,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "hickory-resolver"
-version = "0.25.2"
+name = "hickory-proto"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
+ "hickory-net",
  "hickory-proto",
  "ipconfig",
+ "ipnet",
+ "jni",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.10.1",
  "resolv-conf",
  "smallvec",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1983,6 +2005,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-docker"
@@ -2329,6 +2354,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2689,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,7 +2847,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3038,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -3232,7 +3274,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3277,7 +3319,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -3289,7 +3331,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3396,7 +3438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3976,6 +4018,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,7 +4060,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4885,7 +4948,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bumps `hickory-proto` to `0.26.1`, fixing [GHSA-q2qq-hmj6-3wpp](https://github.com/advisories/GHSA-q2qq-hmj6-3wpp) (O(n²) name compression in `BinEncoder`, CPU-exhaustion DoS via crafted messages — mirrors CVE-2024-8508). Closes CIP-3808.

**`Cargo.lock` only — no `Cargo.toml` changes.**

## Why this wasn't a mechanical bump

`hickory-proto` is transitive: `tests/sqlx` → `cipherstash-client = "=0.42.0"` → `reqwest ^0.13` → `hickory-resolver ^0.25` → `hickory-proto ^0.25`.

A direct `cargo update hickory-proto --precise 0.26.1` fails, because it only tries to move that one package while `hickory-resolver 0.25.2` (locked) still requires `hickory-proto ^0.25`:

```
error: failed to select a version for the requirement `hickory-proto = "^0.25"`
candidate versions found which didn't match: 0.26.1
required by package `hickory-resolver v0.25.2`
    ... which satisfies dependency `hickory-resolver = "^0.25"` (locked to 0.25.2) of package `reqwest v0.13.3`
    ... which satisfies dependency `reqwest = "^0.13"` (locked to 0.13.3) of package `cipherstash-client v0.42.0`
    ... which satisfies dependency `cipherstash-client = "=0.42.0"` (locked to 0.42.0) of package `eql_tests v0.1.0`
```

I initially suspected the `=0.42.0` exact pin on `cipherstash-client` (in `tests/sqlx/Cargo.toml`, deliberately pinned so its SteVec envelope format can't drift independently of the fixtures/bindings this repo tests against) was the real blocker, and that relaxing it to `0.42.2` would be required to move `hickory-proto`. That turned out not to be necessary:

- `cipherstash-client`'s own `reqwest` requirement is `^0.13` in **both** 0.42.0 and 0.42.2 — unchanged, so relaxing the pin wouldn't have changed dependency resolution at all here.
- The real cause was simpler: `reqwest 0.13.3` (the version locked in `Cargo.lock`) depends on `hickory-resolver ^0.25`, but `reqwest 0.13.4` — already within `cipherstash-client`'s allowed `^0.13` range, just never pulled in because nobody re-ran `cargo update` after it was published — depends on `hickory-resolver ^0.26`, which in turn requires `hickory-proto ^0.26`.

So the fix is `cargo update -p reqwest --precise 0.13.4`, which cascades correctly through the whole `reqwest → hickory-resolver → hickory-proto` chain in one coherent step:

```
Updating hickory-proto v0.25.2 -> v0.26.1
Updating hickory-resolver v0.25.2 -> v0.26.1
Updating reqwest v0.13.3 -> v0.13.4
```

`cipherstash-client` stays exactly pinned at `0.42.0` — untouched — so the SteVec envelope / fixture-compatibility concern behind that pin's comment doesn't apply here at all.

## Verification

- `cargo tree -i hickory-proto` confirms a single resolved version, `hickory-proto v0.26.1`, matching the advisory's patched version.
- `cargo check -p eql_tests --all-targets`: all real dependency and workspace code compiles cleanly (`hickory-proto`, `hickory-resolver`, `reqwest 0.13.4`, `stack-auth`, `cipherstash-client 0.42.0`, `eql_tests` all pass). The only errors are 5 pre-existing "file not found" errors for one locally-missing, gitignored, generated fixture (`v3_text_empty_bloom.sql`, regenerated via `mise run fixture:generate:all` which needs ZeroKMS creds not present in this environment) — confirmed unrelated to this change by reproducing the same class of failure (worse — 21 errors across several missing fixtures) against a completely clean, unmodified `main` checkout with no dependency changes at all.
- The credential-free, DB-free `catalog` proptest suite (`cargo test -p eql-domains --lib proptest_invariants`), which exercises `eql-domains` catalog invariants, passes cleanly: 6/6 tests.
- Since `cipherstash-client` was never touched, the fixture-oracle / SteVec-payload-compatibility tests this PR would otherwise need to worry about (per the pin's comment in `tests/sqlx/Cargo.toml`) are not implicated — there is no cipherstash-client version change for them to catch.

## Out of scope

CIP-3792 (a *different* `hickory-proto` advisory, GHSA-3v94-mw7p-v465, with no released fix at time of writing) is not addressed here.
