### PR TITLE
docs: note that this repo has moved to cipherstash/stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Encrypt Query Language (EQL)
 
+> [!IMPORTANT]
+> **This repository has moved.** EQL now lives inside [`cipherstash/stack`](https://github.com/cipherstash/stack), at `packages/eql`. This repo is no longer actively developed — please open issues and pull requests in `cipherstash/stack` instead.
+
 [![Test EQL](https://github.com/cipherstash/encrypt-query-language/actions/workflows/test-eql.yml/badge.svg?branch=main)](https://github.com/cipherstash/encrypt-query-language/actions/workflows/test-eql.yml)
 [![Release EQL](https://github.com/cipherstash/encrypt-query-language/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/cipherstash/encrypt-query-language/actions/workflows/release.yml)
 


### PR DESCRIPTION
## Summary

EQL's source has moved into `cipherstash/stack` (`packages/eql`). This repo is no longer where development happens, but anyone who lands here — from a search engine, an old link, or a release page — has no way to know that. This adds a notice to the README pointing them to the new location.

## Changes

- README: add a "this repository has moved" notice at the top, linking to `packages/eql` in `cipherstash/stack`.

## Verification

Docs-only change; rendered the Markdown locally to confirm the GitHub alert box formats correctly.

## Related

Part of the EQL → `cipherstash/stack` migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a prominent notice that the repository has moved to a new location.
  * Clarified that the repository is no longer actively developed and should not receive new issues or pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->